### PR TITLE
Add initial common files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,8 @@
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>1.8.5</mockito.version>
+        <mockito.version>2.28.2</mockito.version>
+        <hamcrest.version>2.2</hamcrest.version>
     </properties>
 
     <dependencies>
@@ -96,6 +97,21 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>1.12</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/src/main/java/de/aservo/atlassian/confapi/exception/NoContentException.java
+++ b/src/main/java/de/aservo/atlassian/confapi/exception/NoContentException.java
@@ -1,0 +1,11 @@
+package de.aservo.atlassian.confapi.exception;
+
+public class NoContentException extends Exception {
+
+    public NoContentException(
+            final String message) {
+
+        super(message);
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/helper/WebAuthenticationHelper.java
+++ b/src/main/java/de/aservo/atlassian/confapi/helper/WebAuthenticationHelper.java
@@ -1,0 +1,26 @@
+package de.aservo.atlassian.confapi.helper;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+public interface WebAuthenticationHelper<U> {
+
+    U getAuthenticatedUser();
+
+    boolean isSystemAdministrator(U user);
+
+    default void mustBeSysAdmin() {
+        final U user = getAuthenticatedUser();
+
+        if (user == null) {
+            // NOSONAR: Ignore that WebApplicationException is a RuntimeException
+            throw new WebApplicationException(Response.Status.UNAUTHORIZED);
+        }
+
+        if (!isSystemAdministrator(user)) {
+            // NOSONAR: Ignore that WebApplicationException is a RuntimeException
+            throw new WebApplicationException(Response.Status.FORBIDDEN);
+        }
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/model/ErrorCollection.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/ErrorCollection.java
@@ -1,0 +1,45 @@
+package de.aservo.atlassian.confapi.model;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+@XmlRootElement
+public class ErrorCollection {
+
+    @XmlElement
+    private final Collection<String> errorMessages = new ArrayList<>();
+
+    public ErrorCollection addErrorMessage(String errorMessage) {
+        if (errorMessage != null) {
+            errorMessages.add(errorMessage);
+        }
+        return this;
+    }
+
+    public ErrorCollection addErrorMessages(Collection<String> messages) {
+        if (messages != null) {
+            messages.forEach(this::addErrorMessage);
+        }
+        return this;
+    }
+
+    public boolean hasAnyErrors() {
+        return !errorMessages.isEmpty();
+    }
+
+    public Collection<String> getErrorMessages() {
+        return errorMessages;
+    }
+
+    public static ErrorCollection of(String... messages) {
+        return of(Arrays.asList(messages));
+    }
+
+    public static ErrorCollection of(Collection<String> messages) {
+        return new ErrorCollection().addErrorMessages(messages);
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/model/PopMailServerBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/PopMailServerBean.java
@@ -1,0 +1,143 @@
+package de.aservo.atlassian.confapi.model;
+
+import com.atlassian.mail.server.PopMailServer;
+import de.aservo.atlassian.confapi.exception.NoContentException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeExclude;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import static com.atlassian.mail.MailConstants.DEFAULT_TIMEOUT;
+
+/**
+ * Bean for POP mail server in REST requests.
+ */
+@XmlRootElement(name = PopMailServerBean.POP_NAME)
+public class PopMailServerBean {
+
+    public static final String POP_NAME = "pop";
+
+    @XmlElement
+    private final String name;
+
+    @XmlElement
+    private final String description;
+
+    @XmlElement
+    private final String protocol;
+
+    @XmlElement
+    private final String host;
+
+    @XmlElement
+    private final Integer port;
+
+    @XmlElement
+    private final long timeout;
+
+    @XmlElement
+    private final String username;
+
+    @XmlElement
+    @EqualsExclude
+    @HashCodeExclude
+    private final String password;
+
+    /**
+     * The default constructor is needed for JSON request deserialization.
+     */
+    public PopMailServerBean() {
+        this.name = null;
+        this.description = null;
+        this.protocol = null;
+        this.host = null;
+        this.port = null;
+        this.timeout = DEFAULT_TIMEOUT;
+        this.username = null;
+        this.password = null;
+    }
+
+    private PopMailServerBean(
+            final String name,
+            final String description,
+            final String protocol,
+            final String host,
+            final Integer port,
+            final long timeout,
+            final String username) {
+
+        this.name = name;
+        this.description = StringUtils.isNoneBlank(description) ? description : null;
+        this.protocol = protocol;
+        this.host = host;
+        this.port = port;
+        this.timeout = timeout;
+        this.username = username;
+        this.password = null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getProtocol() {
+        return protocol != null ? protocol.toLowerCase() : null;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public long getTimeout() {
+        return timeout;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public static PopMailServerBean from(
+            final PopMailServer popMailServer) throws NoContentException {
+
+        if (popMailServer == null) {
+            throw new NoContentException("No POP mail server defined");
+        }
+
+        return new PopMailServerBean(
+                popMailServer.getName(),
+                popMailServer.getDescription(),
+                popMailServer.getMailProtocol().getProtocol(),
+                popMailServer.getHostname(),
+                StringUtils.isNotBlank(popMailServer.getPort()) ? Integer.parseInt(popMailServer.getPort()) : null,
+                popMailServer.getTimeout(),
+                popMailServer.getUsername());
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/model/SettingsBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/SettingsBean.java
@@ -1,0 +1,58 @@
+package de.aservo.atlassian.confapi.model;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean for general settings in REST requests.
+ */
+@XmlRootElement(name = SettingsBean.SETTINGS_NAME)
+public class SettingsBean {
+
+    public static final String SETTINGS_NAME = "settings";
+
+    @XmlElement
+    private final String baseurl;
+
+    @XmlElement
+    private final String title;
+
+    /**
+     * The default constructor is needed for JSON request deserialization.
+     */
+    public SettingsBean() {
+        this.baseurl = null;
+        this.title = null;
+    }
+
+    public SettingsBean(
+            final String baseurl,
+            final String title) {
+
+        this.baseurl = baseurl;
+        this.title = title;
+    }
+
+    public String getBaseurl() {
+        return baseurl;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/model/SmtpMailServerBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/SmtpMailServerBean.java
@@ -1,0 +1,176 @@
+package de.aservo.atlassian.confapi.model;
+
+import com.atlassian.mail.server.SMTPMailServer;
+import de.aservo.atlassian.confapi.exception.NoContentException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeExclude;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import static com.atlassian.mail.MailConstants.DEFAULT_TIMEOUT;
+
+/**
+ * Bean for SMTP mail server in REST requests.
+ */
+@XmlRootElement(name = SmtpMailServerBean.SMTP_NAME)
+public class SmtpMailServerBean {
+
+    public static final String SMTP_NAME = "smtp";
+
+    @XmlElement
+    private final String name;
+
+    @XmlElement
+    private final String description;
+
+    @XmlElement
+    private final String from;
+
+    @XmlElement
+    private final String prefix;
+
+    @XmlElement
+    private final String protocol;
+
+    @XmlElement
+    private final String host;
+
+    @XmlElement
+    private final Integer port;
+
+    @XmlElement
+    private final boolean tls;
+
+    @XmlElement
+    private final long timeout;
+
+    @XmlElement
+    private final String username;
+
+    @XmlElement
+    @EqualsExclude
+    @HashCodeExclude
+    private final String password;
+
+    /**
+     * The default constructor is needed for JSON request deserialization.
+     */
+    public SmtpMailServerBean() {
+        this.name = null;
+        this.description = null;
+        this.from = null;
+        this.prefix = null;
+        this.protocol = null;
+        this.host = null;
+        this.port = null;
+        this.tls = false;
+        this.timeout = DEFAULT_TIMEOUT;
+        this.username = null;
+        this.password = null;
+    }
+
+    private SmtpMailServerBean(
+            final String name,
+            final String description,
+            final String from,
+            final String prefix,
+            final String protocol,
+            final String host,
+            final Integer port,
+            final boolean tls,
+            final long timeout,
+            final String username) {
+
+        this.name = name;
+        this.description = StringUtils.isNoneBlank(description) ? description : null;
+        this.from = from;
+        this.prefix = prefix;
+        this.protocol = protocol;
+        this.host = host;
+        this.port = port;
+        this.tls = tls;
+        this.timeout = timeout;
+        this.username = username;
+        this.password = null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String getProtocol() {
+        return protocol != null ? protocol.toLowerCase() : null;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public boolean isTls() {
+        return tls;
+    }
+
+    public long getTimeout() {
+        return timeout;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public static SmtpMailServerBean from(
+            final SMTPMailServer smtpMailServer) throws NoContentException {
+
+        if (smtpMailServer == null) {
+            throw new NoContentException("No SMTP mail server defined");
+        }
+
+        return new SmtpMailServerBean(
+                smtpMailServer.getName(),
+                smtpMailServer.getDescription(),
+                smtpMailServer.getDefaultFrom(),
+                smtpMailServer.getPrefix(),
+                smtpMailServer.getMailProtocol().getProtocol(),
+                smtpMailServer.getHostname(),
+                StringUtils.isNotBlank(smtpMailServer.getPort()) ? Integer.parseInt(smtpMailServer.getPort()) : null,
+                smtpMailServer.isTlsRequired(),
+                smtpMailServer.getTimeout(),
+                smtpMailServer.getUsername());
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/util/MailProtocolUtil.java
+++ b/src/main/java/de/aservo/atlassian/confapi/util/MailProtocolUtil.java
@@ -1,0 +1,26 @@
+package de.aservo.atlassian.confapi.util;
+
+import com.atlassian.mail.MailProtocol;
+
+import java.util.Arrays;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class MailProtocolUtil {
+
+    private MailProtocolUtil() {}
+
+    public static MailProtocol find(
+            final String protocol,
+            final MailProtocol defaultMailProtocol) {
+
+        if (isBlank(protocol)) {
+            return defaultMailProtocol;
+        }
+
+        return Arrays.stream(MailProtocol.values())
+                .filter(p -> p.getProtocol().equals(protocol))
+                .findAny().orElse(defaultMailProtocol);
+    }
+
+}

--- a/src/test/java/atlassian/mail/server/DefaultTestMailServer.java
+++ b/src/test/java/atlassian/mail/server/DefaultTestMailServer.java
@@ -1,0 +1,14 @@
+package atlassian.mail.server;
+
+import com.atlassian.mail.server.MailServer;
+
+public interface DefaultTestMailServer extends MailServer {
+
+    String NAME = "ASERVO Mail";
+    String DESCRIPTION = NAME + " Description";
+    String HOST = "mail.aservo.com";
+    long TIMEOUT = 0L;
+    String USERNAME = "username";
+    String PASSWORD = "p4$$w0rd";
+
+}

--- a/src/test/java/atlassian/mail/server/DefaultTestPopMailServer.java
+++ b/src/test/java/atlassian/mail/server/DefaultTestPopMailServer.java
@@ -1,0 +1,12 @@
+package atlassian.mail.server;
+
+import com.atlassian.mail.MailConstants;
+import com.atlassian.mail.MailProtocol;
+import com.atlassian.mail.server.PopMailServer;
+
+public interface DefaultTestPopMailServer extends DefaultTestMailServer, PopMailServer {
+
+    MailProtocol PROTOCOL = MailConstants.DEFAULT_POP_PROTOCOL;
+    String PORT = PROTOCOL.getDefaultPort();
+
+}

--- a/src/test/java/atlassian/mail/server/DefaultTestPopMailServerImpl.java
+++ b/src/test/java/atlassian/mail/server/DefaultTestPopMailServerImpl.java
@@ -1,0 +1,21 @@
+package atlassian.mail.server;
+
+import com.atlassian.mail.server.impl.PopMailServerImpl;
+
+public class DefaultTestPopMailServerImpl extends PopMailServerImpl implements DefaultTestPopMailServer {
+
+    public DefaultTestPopMailServerImpl() {
+        super(
+                null,
+                NAME,
+                DESCRIPTION,
+                PROTOCOL,
+                HOST,
+                PORT,
+                USERNAME,
+                PASSWORD,
+                TIMEOUT
+        );
+    }
+
+}

--- a/src/test/java/atlassian/mail/server/DefaultTestSmtpMailServer.java
+++ b/src/test/java/atlassian/mail/server/DefaultTestSmtpMailServer.java
@@ -1,0 +1,15 @@
+package atlassian.mail.server;
+
+import com.atlassian.mail.MailConstants;
+import com.atlassian.mail.MailProtocol;
+import com.atlassian.mail.server.SMTPMailServer;
+
+public interface DefaultTestSmtpMailServer extends DefaultTestMailServer, SMTPMailServer {
+
+    String FROM = "mail@aservo.com";
+    String PREFIX = "[ASERVO]";
+    boolean TLS_REQUIRED = false;
+    MailProtocol PROTOCOL = MailConstants.DEFAULT_SMTP_PROTOCOL;
+    String PORT = PROTOCOL.getDefaultPort();
+
+}

--- a/src/test/java/atlassian/mail/server/DefaultTestSmtpMailServerImpl.java
+++ b/src/test/java/atlassian/mail/server/DefaultTestSmtpMailServerImpl.java
@@ -1,0 +1,25 @@
+package atlassian.mail.server;
+
+import com.atlassian.mail.server.impl.SMTPMailServerImpl;
+
+public class DefaultTestSmtpMailServerImpl extends SMTPMailServerImpl implements DefaultTestSmtpMailServer {
+
+    public DefaultTestSmtpMailServerImpl() {
+        super(
+                null,
+                NAME,
+                DESCRIPTION,
+                FROM,
+                PREFIX,
+                false,
+                PROTOCOL,
+                HOST,
+                PORT,
+                TLS_REQUIRED,
+                USERNAME,
+                PASSWORD,
+                TIMEOUT
+        );
+    }
+
+}

--- a/src/test/java/atlassian/mail/server/OtherTestMailServer.java
+++ b/src/test/java/atlassian/mail/server/OtherTestMailServer.java
@@ -1,0 +1,14 @@
+package atlassian.mail.server;
+
+import com.atlassian.mail.server.MailServer;
+
+public interface OtherTestMailServer extends MailServer {
+
+    String NAME = "OTHER Mail";
+    String DESCRIPTION = NAME + " Description";
+    String HOST = "other.aservo.com";
+    long TIMEOUT = 10000L;
+    String USERNAME = "otheruser";
+    String PASSWORD = "otherpass";
+
+}

--- a/src/test/java/atlassian/mail/server/OtherTestPopMailServer.java
+++ b/src/test/java/atlassian/mail/server/OtherTestPopMailServer.java
@@ -1,0 +1,11 @@
+package atlassian.mail.server;
+
+import com.atlassian.mail.MailProtocol;
+import com.atlassian.mail.server.PopMailServer;
+
+public interface OtherTestPopMailServer extends DefaultTestMailServer, PopMailServer {
+
+    MailProtocol PROTOCOL = MailProtocol.IMAP;
+    String PORT = PROTOCOL.getDefaultPort();
+
+}

--- a/src/test/java/atlassian/mail/server/OtherTestPopMailServerImpl.java
+++ b/src/test/java/atlassian/mail/server/OtherTestPopMailServerImpl.java
@@ -1,0 +1,23 @@
+package atlassian.mail.server;
+
+import com.atlassian.mail.server.impl.PopMailServerImpl;
+
+public class OtherTestPopMailServerImpl extends PopMailServerImpl implements OtherTestPopMailServer {
+
+    public OtherTestPopMailServerImpl() {
+        super(
+                null,
+                NAME,
+                DESCRIPTION,
+                PROTOCOL,
+                HOST,
+                PORT,
+                USERNAME,
+                PASSWORD,
+                TIMEOUT
+        );
+    }
+
+
+
+}

--- a/src/test/java/atlassian/mail/server/OtherTestSmtpMailServer.java
+++ b/src/test/java/atlassian/mail/server/OtherTestSmtpMailServer.java
@@ -1,0 +1,14 @@
+package atlassian.mail.server;
+
+import com.atlassian.mail.MailProtocol;
+import com.atlassian.mail.server.SMTPMailServer;
+
+public interface OtherTestSmtpMailServer extends DefaultTestMailServer, SMTPMailServer {
+
+    String FROM = "from.other@aservo.com";
+    String PREFIX = "[OTHER]";
+    boolean TLS_REQUIRED = true;
+    MailProtocol PROTOCOL = MailProtocol.SECURE_SMTP;
+    String PORT = PROTOCOL.getDefaultPort();
+
+}

--- a/src/test/java/atlassian/mail/server/OtherTestSmtpMailServerImpl.java
+++ b/src/test/java/atlassian/mail/server/OtherTestSmtpMailServerImpl.java
@@ -1,0 +1,25 @@
+package atlassian.mail.server;
+
+import com.atlassian.mail.server.impl.SMTPMailServerImpl;
+
+public class OtherTestSmtpMailServerImpl extends SMTPMailServerImpl implements OtherTestSmtpMailServer {
+
+    public OtherTestSmtpMailServerImpl() {
+        super(
+                null,
+                NAME,
+                DESCRIPTION,
+                FROM,
+                PREFIX,
+                false,
+                PROTOCOL,
+                HOST,
+                PORT,
+                TLS_REQUIRED,
+                USERNAME,
+                PASSWORD,
+                TIMEOUT
+        );
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confapi/exception/NoContentExceptionTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/exception/NoContentExceptionTest.java
@@ -1,0 +1,17 @@
+package de.aservo.atlassian.confapi.exception;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class NoContentExceptionTest {
+
+    public static final String MESSAGE = "No content";
+
+    @Test
+    public void test() {
+        final NoContentException noContentException = new NoContentException(MESSAGE);
+        assertEquals(MESSAGE, noContentException.getMessage());
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confapi/helper/WebAuthenticationHelperTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/helper/WebAuthenticationHelperTest.java
@@ -1,0 +1,58 @@
+package de.aservo.atlassian.confapi.helper;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.ws.rs.WebApplicationException;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WebAuthenticationHelperTest {
+
+    private final Object user = new Object();
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Spy
+    private WebAuthenticationHelper<Object> webAuthenticationHelper = new WebAuthenticationHelper<Object>() {
+        @Override
+        public Object getAuthenticatedUser() {
+            return null;
+        }
+
+        @Override
+        public boolean isSystemAdministrator(Object user) {
+            return false;
+        }
+    };
+
+    @Test
+    public void testNotAuthenticated() {
+        when(webAuthenticationHelper.getAuthenticatedUser()).thenReturn(null);
+        exceptionRule.expect(WebApplicationException.class);
+        webAuthenticationHelper.mustBeSysAdmin();
+    }
+
+    @Test
+    public void testNotSysAdmin() {
+        when(webAuthenticationHelper.getAuthenticatedUser()).thenReturn(user);
+        when(webAuthenticationHelper.isSystemAdministrator(user)).thenReturn(false);
+        exceptionRule.expect(WebApplicationException.class);
+        webAuthenticationHelper.mustBeSysAdmin();
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699") // Ignore that no assertion is present
+    public void testIsSysAdmin() {
+        when(webAuthenticationHelper.getAuthenticatedUser()).thenReturn(user);
+        when(webAuthenticationHelper.isSystemAdministrator(user)).thenReturn(true);
+        webAuthenticationHelper.mustBeSysAdmin();
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confapi/model/ErrorCollectionTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/ErrorCollectionTest.java
@@ -1,0 +1,77 @@
+package de.aservo.atlassian.confapi.model;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ErrorCollectionTest {
+
+    public static final String FIRST_ERROR_MESSAGE = "First error message";
+    public static final String SECOND_ERROR_MESSAGE = "Second error message";
+
+    private ErrorCollection errorCollection;
+
+    @Before
+    public void setup() {
+        errorCollection = new ErrorCollection();
+    }
+
+    @Test
+    public void testDefaultConstructor() {
+        assertFalse(errorCollection.hasAnyErrors());
+    }
+
+    @Test
+    public void testAddErrorMessage() {
+        errorCollection.addErrorMessage(FIRST_ERROR_MESSAGE);
+        assertTrue(errorCollection.hasAnyErrors());
+        assertThat(errorCollection.getErrorMessages().size(), is(1));
+        assertThat(errorCollection.getErrorMessages(), hasItems(FIRST_ERROR_MESSAGE));
+    }
+
+    @Test
+    public void testAddNullErrorMessage() {
+        errorCollection.addErrorMessage(null);
+        assertFalse(errorCollection.hasAnyErrors());
+    }
+
+    @Test
+    public void testAddErrorMessageList() {
+        errorCollection.addErrorMessages(Arrays.asList(FIRST_ERROR_MESSAGE, SECOND_ERROR_MESSAGE));
+        assertTrue(errorCollection.hasAnyErrors());
+        assertThat(errorCollection.getErrorMessages().size(), is(2));
+        assertThat(errorCollection.getErrorMessages(), containsInAnyOrder(FIRST_ERROR_MESSAGE, SECOND_ERROR_MESSAGE));
+    }
+
+    @Test
+    public void testAddNullErrorMessageList() {
+        errorCollection.addErrorMessages(null);
+        assertFalse(errorCollection.hasAnyErrors());
+    }
+
+    @Test
+    public void testOfErrorMessages() {
+        errorCollection = ErrorCollection.of(FIRST_ERROR_MESSAGE, SECOND_ERROR_MESSAGE);
+        assertTrue(errorCollection.hasAnyErrors());
+        assertThat(errorCollection.getErrorMessages().size(), is(2));
+        assertThat(errorCollection.getErrorMessages(), containsInAnyOrder(FIRST_ERROR_MESSAGE, SECOND_ERROR_MESSAGE));
+    }
+
+    @Test
+    public void testOfErrorMessageList() {
+        errorCollection = ErrorCollection.of(Arrays.asList(FIRST_ERROR_MESSAGE, SECOND_ERROR_MESSAGE));
+        assertTrue(errorCollection.hasAnyErrors());
+        assertThat(errorCollection.getErrorMessages().size(), is(2));
+        assertThat(errorCollection.getErrorMessages(), containsInAnyOrder(FIRST_ERROR_MESSAGE, SECOND_ERROR_MESSAGE));
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confapi/model/PopMailServerBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/PopMailServerBeanTest.java
@@ -1,0 +1,54 @@
+package de.aservo.atlassian.confapi.model;
+
+import atlassian.mail.server.DefaultTestPopMailServerImpl;
+import com.atlassian.mail.server.PopMailServer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static com.atlassian.mail.MailConstants.DEFAULT_TIMEOUT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PopMailServerBeanTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        final PopMailServerBean bean = new PopMailServerBean();
+
+        assertNull(bean.getName());
+        assertNull(bean.getDescription());
+        assertNull(bean.getProtocol());
+        assertNull(bean.getHost());
+        assertNull(bean.getPort());
+        assertEquals(DEFAULT_TIMEOUT, bean.getTimeout());
+        assertNull(bean.getUsername());
+        assertNull(bean.getPassword());
+    }
+
+    @Test
+    public void testFromConstructor() throws Exception {
+        final PopMailServer server = new DefaultTestPopMailServerImpl();
+        final PopMailServerBean bean = PopMailServerBean.from(server);
+
+        assertEquals(server.getName(), bean.getName());
+        assertEquals(server.getDescription(), bean.getDescription());
+        assertEquals(server.getMailProtocol().getProtocol(), bean.getProtocol());
+        assertEquals(server.getHostname(), bean.getHost());
+        assertEquals(Integer.valueOf(server.getPort()), bean.getPort());
+        assertEquals(server.getTimeout(), bean.getTimeout());
+        assertEquals(server.getUsername(), bean.getUsername());
+        assertNull(bean.getPassword());
+    }
+
+    @Test
+    public void testFromConstructorHideEmptyDescription() throws Exception {
+        final PopMailServer server = new DefaultTestPopMailServerImpl();
+        server.setDescription("");
+        final PopMailServerBean bean = PopMailServerBean.from(server);
+
+        assertNull(bean.getDescription());
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confapi/model/SettingsBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/SettingsBeanTest.java
@@ -1,0 +1,35 @@
+package de.aservo.atlassian.confapi.model;
+
+import atlassian.mail.server.DefaultTestSmtpMailServerImpl;
+import com.atlassian.mail.server.SMTPMailServer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SettingsBeanTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        final SettingsBean bean = new SettingsBean();
+
+        assertNull(bean.getBaseurl());
+        assertNull(bean.getTitle());
+    }
+
+    @Test
+    public void testParameterConstructor() throws Exception {
+        final String baseurl = "http://localhost/product";
+        final String title = "PRODUCT";
+
+        final SMTPMailServer server = new DefaultTestSmtpMailServerImpl();
+        final SettingsBean bean = new SettingsBean(baseurl, title);
+
+        assertEquals(baseurl, bean.getBaseurl());
+        assertEquals(title, bean.getTitle());
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confapi/model/SmtpMailServerBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/SmtpMailServerBeanTest.java
@@ -1,0 +1,59 @@
+package de.aservo.atlassian.confapi.model;
+
+import atlassian.mail.server.DefaultTestSmtpMailServerImpl;
+import com.atlassian.mail.server.SMTPMailServer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static com.atlassian.mail.MailConstants.DEFAULT_TIMEOUT;
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SmtpMailServerBeanTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        final SmtpMailServerBean bean = new SmtpMailServerBean();
+
+        assertNull(bean.getName());
+        assertNull(bean.getDescription());
+        assertNull(bean.getFrom());
+        assertNull(bean.getPrefix());
+        assertNull(bean.getProtocol());
+        assertNull(bean.getHost());
+        assertNull(bean.getPort());
+        assertFalse(bean.isTls());
+        assertEquals(DEFAULT_TIMEOUT, bean.getTimeout());
+        assertNull(bean.getUsername());
+        assertNull(bean.getPassword());
+    }
+
+    @Test
+    public void testFromConstructor() throws Exception {
+        final SMTPMailServer server = new DefaultTestSmtpMailServerImpl();
+        final SmtpMailServerBean bean = SmtpMailServerBean.from(server);
+
+        assertEquals(server.getName(), bean.getName());
+        assertEquals(server.getDescription(), bean.getDescription());
+        assertEquals(server.getDefaultFrom(), bean.getFrom());
+        assertEquals(server.getPrefix(), bean.getPrefix());
+        assertEquals(server.getMailProtocol().getProtocol(), bean.getProtocol());
+        assertEquals(server.getHostname(), bean.getHost());
+        assertEquals(Integer.valueOf(server.getPort()), bean.getPort());
+        assertEquals(server.isTlsRequired(), bean.isTls());
+        assertEquals(server.getTimeout(), bean.getTimeout());
+        assertEquals(server.getUsername(), bean.getUsername());
+        assertNull(bean.getPassword());
+    }
+
+    @Test
+    public void testFromConstructorHideEmptyDescription() throws Exception {
+        final SMTPMailServer server = new DefaultTestSmtpMailServerImpl();
+        server.setDescription("");
+        final SmtpMailServerBean bean = SmtpMailServerBean.from(server);
+
+        assertNull(bean.getDescription());
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confapi/util/MailProtocolUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/util/MailProtocolUtilTest.java
@@ -1,0 +1,32 @@
+package de.aservo.atlassian.confapi.util;
+
+import com.atlassian.mail.MailProtocol;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MailProtocolUtilTest {
+
+    @Test
+    public void testFind() {
+        final MailProtocol protocolImap = MailProtocolUtil.find(MailProtocol.IMAP.getProtocol(), null);
+        assertEquals(MailProtocol.IMAP, protocolImap);
+    }
+
+    @Test
+    public void testFindNotFoundDefaultValue() {
+        final MailProtocol protocolDefault = MailProtocolUtil.find("abc", null);
+        assertNull(protocolDefault);
+    }
+
+    @Test
+    public void testFindBlankDefaultValue() {
+        final MailProtocol protocolDefault = MailProtocolUtil.find("", null);
+        assertNull(protocolDefault);
+    }
+
+}


### PR DESCRIPTION
With this commit the first base for the ConfAPI library has been implemented.
This library includes some adjusted sources of the confluence-confapi-plugin.
Thinks that have been taken over are:

* exception
* helper
    The WebAuthenticationHelper is now implemented as a generic interface
    that can easily be reused amongst all the plugin although different
    Atlassian interfaces are used.
* model
    The from-constructor for the settings bean has been removed as there is no
    common Atlassian interface for the settings. The other beans have been taken
    over.
* util