### PR TITLE
Build tests JAR, rename test data package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,23 @@
             <version>1.12</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/test/java/com/atlassian/mail/server/DefaultTestMailServer.java
+++ b/src/test/java/com/atlassian/mail/server/DefaultTestMailServer.java
@@ -1,4 +1,4 @@
-package atlassian.mail.server;
+package com.atlassian.mail.server;
 
 import com.atlassian.mail.server.MailServer;
 

--- a/src/test/java/com/atlassian/mail/server/DefaultTestPopMailServer.java
+++ b/src/test/java/com/atlassian/mail/server/DefaultTestPopMailServer.java
@@ -1,8 +1,7 @@
-package atlassian.mail.server;
+package com.atlassian.mail.server;
 
 import com.atlassian.mail.MailConstants;
 import com.atlassian.mail.MailProtocol;
-import com.atlassian.mail.server.PopMailServer;
 
 public interface DefaultTestPopMailServer extends DefaultTestMailServer, PopMailServer {
 

--- a/src/test/java/com/atlassian/mail/server/DefaultTestPopMailServerImpl.java
+++ b/src/test/java/com/atlassian/mail/server/DefaultTestPopMailServerImpl.java
@@ -1,10 +1,10 @@
-package atlassian.mail.server;
+package com.atlassian.mail.server;
 
 import com.atlassian.mail.server.impl.PopMailServerImpl;
 
-public class OtherTestPopMailServerImpl extends PopMailServerImpl implements OtherTestPopMailServer {
+public class DefaultTestPopMailServerImpl extends PopMailServerImpl implements DefaultTestPopMailServer {
 
-    public OtherTestPopMailServerImpl() {
+    public DefaultTestPopMailServerImpl() {
         super(
                 null,
                 NAME,
@@ -17,7 +17,5 @@ public class OtherTestPopMailServerImpl extends PopMailServerImpl implements Oth
                 TIMEOUT
         );
     }
-
-
 
 }

--- a/src/test/java/com/atlassian/mail/server/DefaultTestSmtpMailServer.java
+++ b/src/test/java/com/atlassian/mail/server/DefaultTestSmtpMailServer.java
@@ -1,8 +1,7 @@
-package atlassian.mail.server;
+package com.atlassian.mail.server;
 
 import com.atlassian.mail.MailConstants;
 import com.atlassian.mail.MailProtocol;
-import com.atlassian.mail.server.SMTPMailServer;
 
 public interface DefaultTestSmtpMailServer extends DefaultTestMailServer, SMTPMailServer {
 

--- a/src/test/java/com/atlassian/mail/server/DefaultTestSmtpMailServerImpl.java
+++ b/src/test/java/com/atlassian/mail/server/DefaultTestSmtpMailServerImpl.java
@@ -1,10 +1,10 @@
-package atlassian.mail.server;
+package com.atlassian.mail.server;
 
 import com.atlassian.mail.server.impl.SMTPMailServerImpl;
 
-public class OtherTestSmtpMailServerImpl extends SMTPMailServerImpl implements OtherTestSmtpMailServer {
+public class DefaultTestSmtpMailServerImpl extends SMTPMailServerImpl implements DefaultTestSmtpMailServer {
 
-    public OtherTestSmtpMailServerImpl() {
+    public DefaultTestSmtpMailServerImpl() {
         super(
                 null,
                 NAME,

--- a/src/test/java/com/atlassian/mail/server/OtherTestMailServer.java
+++ b/src/test/java/com/atlassian/mail/server/OtherTestMailServer.java
@@ -1,4 +1,4 @@
-package atlassian.mail.server;
+package com.atlassian.mail.server;
 
 import com.atlassian.mail.server.MailServer;
 

--- a/src/test/java/com/atlassian/mail/server/OtherTestPopMailServer.java
+++ b/src/test/java/com/atlassian/mail/server/OtherTestPopMailServer.java
@@ -1,7 +1,6 @@
-package atlassian.mail.server;
+package com.atlassian.mail.server;
 
 import com.atlassian.mail.MailProtocol;
-import com.atlassian.mail.server.PopMailServer;
 
 public interface OtherTestPopMailServer extends DefaultTestMailServer, PopMailServer {
 

--- a/src/test/java/com/atlassian/mail/server/OtherTestPopMailServerImpl.java
+++ b/src/test/java/com/atlassian/mail/server/OtherTestPopMailServerImpl.java
@@ -1,10 +1,10 @@
-package atlassian.mail.server;
+package com.atlassian.mail.server;
 
 import com.atlassian.mail.server.impl.PopMailServerImpl;
 
-public class DefaultTestPopMailServerImpl extends PopMailServerImpl implements DefaultTestPopMailServer {
+public class OtherTestPopMailServerImpl extends PopMailServerImpl implements OtherTestPopMailServer {
 
-    public DefaultTestPopMailServerImpl() {
+    public OtherTestPopMailServerImpl() {
         super(
                 null,
                 NAME,
@@ -17,5 +17,7 @@ public class DefaultTestPopMailServerImpl extends PopMailServerImpl implements D
                 TIMEOUT
         );
     }
+
+
 
 }

--- a/src/test/java/com/atlassian/mail/server/OtherTestSmtpMailServer.java
+++ b/src/test/java/com/atlassian/mail/server/OtherTestSmtpMailServer.java
@@ -1,7 +1,6 @@
-package atlassian.mail.server;
+package com.atlassian.mail.server;
 
 import com.atlassian.mail.MailProtocol;
-import com.atlassian.mail.server.SMTPMailServer;
 
 public interface OtherTestSmtpMailServer extends DefaultTestMailServer, SMTPMailServer {
 

--- a/src/test/java/com/atlassian/mail/server/OtherTestSmtpMailServerImpl.java
+++ b/src/test/java/com/atlassian/mail/server/OtherTestSmtpMailServerImpl.java
@@ -1,10 +1,10 @@
-package atlassian.mail.server;
+package com.atlassian.mail.server;
 
 import com.atlassian.mail.server.impl.SMTPMailServerImpl;
 
-public class DefaultTestSmtpMailServerImpl extends SMTPMailServerImpl implements DefaultTestSmtpMailServer {
+public class OtherTestSmtpMailServerImpl extends SMTPMailServerImpl implements OtherTestSmtpMailServer {
 
-    public DefaultTestSmtpMailServerImpl() {
+    public OtherTestSmtpMailServerImpl() {
         super(
                 null,
                 NAME,

--- a/src/test/java/de/aservo/atlassian/confapi/junit/ResourceAssert.java
+++ b/src/test/java/de/aservo/atlassian/confapi/junit/ResourceAssert.java
@@ -1,0 +1,160 @@
+package de.aservo.atlassian.confapi.junit;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.*;
+
+public class ResourceAssert {
+
+    public static void assertResourcePath(
+            final Object resource,
+            final String path) {
+
+        final Class<?> resourceClass = resource.getClass();
+        final Path resourceClassAnnotation = resourceClass.getAnnotation(Path.class);
+        assertNotNull(resourceClassAnnotation);
+        assertEquals(path, resourceClassAnnotation.value());
+    }
+
+    public static void assertResourceMethodGet(
+            final Object resource,
+            final String subPath,
+            final String methodName,
+            final Class<?>... parameterTypes) {
+
+        assertResourceMethodInternal(resource, subPath, HttpMethod.GET, methodName, parameterTypes);
+    }
+
+    public static void assertResourceMethodGetNoSubPath(
+            final Object resource,
+            final String methodName,
+            final Class<?>... parameterTypes) {
+
+        assertResourceMethodInternal(resource, null, HttpMethod.GET, methodName, parameterTypes);
+    }
+
+    public static void assertResourceMethodPost(
+            final Object resource,
+            final String subPath,
+            final String methodName,
+            final Class<?>... parameterTypes) {
+
+        assertResourceMethodInternal(resource, subPath, HttpMethod.POST, methodName, parameterTypes);
+    }
+
+    public static void assertResourceMethodPostNoSubPath(
+            final Object resource,
+            final String methodName,
+            final Class<?>... parameterTypes) {
+
+        assertResourceMethodInternal(resource, null, HttpMethod.POST, methodName, parameterTypes);
+    }
+
+    public static void assertResourceMethodPut(
+            final Object resource,
+            final String subPath,
+            final String methodName,
+            final Class<?>... parameterTypes) {
+
+        assertResourceMethodInternal(resource, subPath, HttpMethod.PUT, methodName, parameterTypes);
+    }
+
+    public static void assertResourceMethodPutNoSubPath(
+            final Object resource,
+            final String methodName,
+            final Class<?>... parameterTypes) {
+
+        assertResourceMethodInternal(resource, null, HttpMethod.PUT, methodName, parameterTypes);
+    }
+
+    public static void assertResourceMethodDelete(
+            final Object resource,
+            final String subPath,
+            final String methodName,
+            final Class<?>... parameterTypes) {
+
+        assertResourceMethodInternal(resource, subPath, HttpMethod.DELETE, methodName, parameterTypes);
+    }
+
+    public static void assertResourceMethodDeleteNoSubPath(
+            final Object resource,
+            final String methodName,
+            final Class<?>... parameterTypes) {
+
+        assertResourceMethodInternal(resource, null, HttpMethod.DELETE, methodName, parameterTypes);
+    }
+
+    private static void assertResourceMethodInternal(
+            final Object resource,
+            final String subPath,
+            final String httpMethod,
+            final String methodName,
+            final Class<?>... parameterTypes) {
+
+        final Class<?> resourceClass = resource.getClass();
+        final Path resourceClassAnnotation = resourceClass.getAnnotation(Path.class);
+        assertNotNull(resourceClassAnnotation);
+
+        final Method method;
+        try {
+            method = resourceClass.getMethod(methodName, parameterTypes);
+        } catch (NoSuchMethodException e) {
+            fail(String.format("Method %s is not defined", methodName));
+            return;
+        }
+
+        assertResourceMethodHttpMethodInternal(method, httpMethod);
+
+        final Path methodPath = method.getAnnotation(Path.class);
+        if (subPath != null) {
+            assertNotNull(methodPath.value());
+            assertEquals(subPath, methodPath.value());
+        } else {
+            assertNull(methodPath);
+        }
+    }
+
+    private static void assertResourceMethodHttpMethodInternal(
+            final Method method,
+            final String httpMethod) {
+
+        switch (httpMethod) {
+            case HttpMethod.GET: {
+                assertNotNull(method.getAnnotation(GET.class));
+                break;
+            }
+            case HttpMethod.POST: {
+                assertNotNull(method.getAnnotation(POST.class));
+                break;
+            }
+            case HttpMethod.PUT: {
+                assertNotNull(method.getAnnotation(PUT.class));
+                break;
+            }
+            case HttpMethod.DELETE: {
+                assertNotNull(method.getAnnotation(DELETE.class));
+                break;
+            }
+            case HttpMethod.HEAD: {
+                assertNotNull(method.getAnnotation(HEAD.class));
+                break;
+            }
+            case HttpMethod.OPTIONS: {
+                assertNotNull(method.getAnnotation(OPTIONS.class));
+                break;
+            }
+            default: {
+                fail(String.format("HTTP method %s not known", httpMethod));
+            }
+        }
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confapi/model/PopMailServerBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/PopMailServerBeanTest.java
@@ -1,6 +1,6 @@
 package de.aservo.atlassian.confapi.model;
 
-import atlassian.mail.server.DefaultTestPopMailServerImpl;
+import com.atlassian.mail.server.DefaultTestPopMailServerImpl;
 import com.atlassian.mail.server.PopMailServer;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/de/aservo/atlassian/confapi/model/SettingsBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/SettingsBeanTest.java
@@ -1,6 +1,6 @@
 package de.aservo.atlassian.confapi.model;
 
-import atlassian.mail.server.DefaultTestSmtpMailServerImpl;
+import com.atlassian.mail.server.DefaultTestSmtpMailServerImpl;
 import com.atlassian.mail.server.SMTPMailServer;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/de/aservo/atlassian/confapi/model/SmtpMailServerBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/SmtpMailServerBeanTest.java
@@ -1,6 +1,6 @@
 package de.aservo.atlassian.confapi.model;
 
-import atlassian.mail.server.DefaultTestSmtpMailServerImpl;
+import com.atlassian.mail.server.DefaultTestSmtpMailServerImpl;
 import com.atlassian.mail.server.SMTPMailServer;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
The contained test data might be useful to use for other unit and integration
tests in the ConfAPI plugins. For that reason, a test JAR containing tests and
test data is now created and deployed together with the library itself.

Furthermore, the test data package for Atlassian mail tests has been renamed as
it has been missing the com prefix.