### PR TITLE
Use @Inject, replace product component annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <lombok.version>1.18.10</lombok.version>
+        <javax.inject.version>1</javax.inject.version>
         <validation-api.version>1.1.0.FINAL</validation-api.version>
         <spring-context.version>5.2.4.RELEASE</spring-context.version>
         <jersey-client.version>1.12</jersey-client.version>
@@ -121,6 +122,13 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>${javax.inject.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/de/aservo/atlassian/confapi/service/UserDirectoryServiceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confapi/service/UserDirectoryServiceImpl.java
@@ -3,17 +3,15 @@ package de.aservo.atlassian.confapi.service;
 import com.atlassian.crowd.embedded.api.CrowdDirectoryService;
 import com.atlassian.crowd.embedded.api.Directory;
 import com.atlassian.crowd.exception.DirectoryCurrentlySynchronisingException;
-import com.atlassian.plugin.spring.scanner.annotation.component.BambooComponent;
-import com.atlassian.plugin.spring.scanner.annotation.component.BitbucketComponent;
-import com.atlassian.plugin.spring.scanner.annotation.component.ConfluenceComponent;
 import com.atlassian.plugin.spring.scanner.annotation.component.JiraComponent;
-import com.atlassian.plugin.spring.scanner.annotation.export.ExportAsService;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import de.aservo.atlassian.confapi.model.UserDirectoryBean;
 import de.aservo.atlassian.confapi.util.BeanValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
+import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -23,10 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * The type User directory service.
  */
-@ExportAsService
-@BambooComponent
-@BitbucketComponent
-@ConfluenceComponent
+@Component
 @JiraComponent
 public class UserDirectoryServiceImpl implements UserDirectoryService {
 
@@ -39,6 +34,7 @@ public class UserDirectoryServiceImpl implements UserDirectoryService {
      *
      * @param crowdDirectoryService the crowd directory service
      */
+    @Inject
     public UserDirectoryServiceImpl(@ComponentImport CrowdDirectoryService crowdDirectoryService) {
         this.crowdDirectoryService = checkNotNull(crowdDirectoryService);
     }

--- a/src/test/java/de/aservo/atlassian/confapi/model/ErrorCollectionTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/ErrorCollectionTest.java
@@ -3,7 +3,7 @@ package de.aservo.atlassian.confapi.model;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 

--- a/src/test/java/de/aservo/atlassian/confapi/model/PopMailServerBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/PopMailServerBeanTest.java
@@ -4,7 +4,7 @@ import com.atlassian.mail.server.DefaultTestPopMailServerImpl;
 import com.atlassian.mail.server.PopMailServer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static com.atlassian.mail.MailConstants.DEFAULT_TIMEOUT;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/de/aservo/atlassian/confapi/model/SettingsBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/SettingsBeanTest.java
@@ -4,7 +4,7 @@ import com.atlassian.mail.server.DefaultTestSmtpMailServerImpl;
 import com.atlassian.mail.server.SMTPMailServer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/src/test/java/de/aservo/atlassian/confapi/model/SmtpMailServerBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/SmtpMailServerBeanTest.java
@@ -4,7 +4,7 @@ import com.atlassian.mail.server.DefaultTestSmtpMailServerImpl;
 import com.atlassian.mail.server.SMTPMailServer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static com.atlassian.mail.MailConstants.DEFAULT_TIMEOUT;
 import static org.junit.Assert.*;

--- a/src/test/java/de/aservo/atlassian/confapi/model/UserDirectoryBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/UserDirectoryBeanTest.java
@@ -5,7 +5,7 @@ import com.atlassian.crowd.embedded.api.DirectoryType;
 import com.atlassian.crowd.model.directory.DirectoryImpl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Map;
 

--- a/src/test/java/de/aservo/atlassian/confapi/service/UserDirectoryServiceTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/service/UserDirectoryServiceTest.java
@@ -6,10 +6,11 @@ import com.atlassian.crowd.embedded.api.DirectoryType;
 import com.atlassian.crowd.exception.DirectoryCurrentlySynchronisingException;
 import com.atlassian.crowd.model.directory.ImmutableDirectory;
 import de.aservo.atlassian.confapi.model.UserDirectoryBean;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.validation.ValidationException;
 import java.util.Collections;
@@ -24,19 +25,15 @@ import static com.atlassian.crowd.model.directory.DirectoryImpl.ATTRIBUTE_KEY_US
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UserDirectoryServiceTest {
 
+    @Mock
     private CrowdDirectoryService crowdDirectoryService;
-    private UserDirectoryService userDirectoryService;
 
-    @Before
-    public void setup() {
-        crowdDirectoryService = mock(CrowdDirectoryService.class);
-        userDirectoryService = new UserDirectoryServiceImpl(crowdDirectoryService);
-    }
+    @InjectMocks
+    private UserDirectoryServiceImpl userDirectoryService;
 
     @Test
     public void testGetDirectories() {

--- a/src/test/java/de/aservo/atlassian/confapi/util/MailProtocolUtilTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/util/MailProtocolUtilTest.java
@@ -3,7 +3,7 @@ package de.aservo.atlassian.confapi.util;
 import com.atlassian.mail.MailProtocol;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;


### PR DESCRIPTION
The use of the UserDirectoryService caused problems in the
confluence-confapi-plugin. This was probably caused by the missing @Inject
annotations and by the product component annotations (like @JiraComponent) as
these are only normal @Component annotations that are also annotated with a
e.g. @OnlyInProduct(ProductFilter.JIRA) annotation. The behaviour for multiple
products is not really clear.

And as these warnings now popped up: The deprecated MockitoJUnitRunner has now
been updated to the current version in the org.mockito.junit package.