### PR TITLE
Add ConfAPI constants class

### DIFF
--- a/src/main/java/de/aservo/atlassian/confapi/constants/ConfAPI.java
+++ b/src/main/java/de/aservo/atlassian/confapi/constants/ConfAPI.java
@@ -1,0 +1,15 @@
+package de.aservo.atlassian.confapi.constants;
+
+public class ConfAPI {
+
+    private ConfAPI() {}
+
+    public static final String DIRECTORIES = "directories";
+    public static final String DIRECTORY   = "directory";
+    public static final String MAIL        = "mail";
+    public static final String MAIL_POP    = "pop";
+    public static final String MAIL_SMTP   = "smtp";
+    public static final String PING        = "ping";
+    public static final String SETTINGS    = "settings";
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/model/PopMailServerBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/PopMailServerBean.java
@@ -1,6 +1,7 @@
 package de.aservo.atlassian.confapi.model;
 
 import com.atlassian.mail.server.PopMailServer;
+import de.aservo.atlassian.confapi.constants.ConfAPI;
 import de.aservo.atlassian.confapi.exception.NoContentException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -16,10 +17,8 @@ import static com.atlassian.mail.MailConstants.DEFAULT_TIMEOUT;
 /**
  * Bean for POP mail server in REST requests.
  */
-@XmlRootElement(name = PopMailServerBean.POP_NAME)
+@XmlRootElement(name = ConfAPI.MAIL_POP)
 public class PopMailServerBean {
-
-    public static final String POP_NAME = "pop";
 
     @XmlElement
     private final String name;

--- a/src/main/java/de/aservo/atlassian/confapi/model/SettingsBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/SettingsBean.java
@@ -1,5 +1,6 @@
 package de.aservo.atlassian.confapi.model;
 
+import de.aservo.atlassian.confapi.constants.ConfAPI;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -9,10 +10,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Bean for general settings in REST requests.
  */
-@XmlRootElement(name = SettingsBean.SETTINGS_NAME)
+@XmlRootElement(name = ConfAPI.SETTINGS)
 public class SettingsBean {
-
-    public static final String SETTINGS_NAME = "settings";
 
     @XmlElement
     private final String baseurl;

--- a/src/main/java/de/aservo/atlassian/confapi/model/SmtpMailServerBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/SmtpMailServerBean.java
@@ -1,6 +1,7 @@
 package de.aservo.atlassian.confapi.model;
 
 import com.atlassian.mail.server.SMTPMailServer;
+import de.aservo.atlassian.confapi.constants.ConfAPI;
 import de.aservo.atlassian.confapi.exception.NoContentException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -16,10 +17,8 @@ import static com.atlassian.mail.MailConstants.DEFAULT_TIMEOUT;
 /**
  * Bean for SMTP mail server in REST requests.
  */
-@XmlRootElement(name = SmtpMailServerBean.SMTP_NAME)
+@XmlRootElement(name = ConfAPI.MAIL_SMTP)
 public class SmtpMailServerBean {
-
-    public static final String SMTP_NAME = "smtp";
 
     @XmlElement
     private final String name;

--- a/src/main/java/de/aservo/atlassian/confapi/model/UserDirectoryBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/UserDirectoryBean.java
@@ -3,6 +3,7 @@ package de.aservo.atlassian.confapi.model;
 import com.atlassian.crowd.embedded.api.Directory;
 import com.atlassian.crowd.embedded.api.DirectoryType;
 import com.atlassian.crowd.model.directory.ImmutableDirectory;
+import de.aservo.atlassian.confapi.constants.ConfAPI;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -23,7 +24,7 @@ import static com.atlassian.crowd.model.directory.DirectoryImpl.ATTRIBUTE_KEY_US
  */
 @Data
 @NoArgsConstructor
-@XmlRootElement(name = "userDirectory")
+@XmlRootElement(name = ConfAPI.DIRECTORY)
 public class UserDirectoryBean {
 
     @XmlElement


### PR DESCRIPTION
In order to make sure that names for REST endpoints and JSON beans are
consistent amongst all ConfAPI plugins, an initial version of a constant class
has been implemented.

Using these constants also simplifies testing, e.g. when building URL's in
integration tests.