### PR TITLE
Rename export constant, add queue, reorder

### DIFF
--- a/src/main/java/de/aservo/atlassian/confapi/constants/ConfAPI.java
+++ b/src/main/java/de/aservo/atlassian/confapi/constants/ConfAPI.java
@@ -4,11 +4,14 @@ public class ConfAPI {
 
     public static final String APPLICATION_LINK             = "application-link";
     public static final String APPLICATION_LINKS            = "application-links";
+    public static final String BACKUP                       = "backup";
+    public static final String BACKUP_EXPORT                = "export";
+    public static final String BACKUP_IMPORT                = "import";
+    public static final String BACKUP_QUEUE                 = "queue";
     public static final String DIRECTORIES                  = "directories";
     public static final String DIRECTORY                    = "directory";
-    public static final String ERRORS                       = "errors";
     public static final String ERROR                        = "error";
-    public static final String EXPORT                       = "export";
+    public static final String ERRORS                       = "errors";
     public static final String GADGET                       = "gadget";
     public static final String GADGETS                      = "gadgets";
     public static final String GADGET_EXTERNAL              = "external";


### PR DESCRIPTION
**NEUESTER STAND, SIEHE --> [HIER](https://github.com/aservo/confapi-commons/pull/9#issuecomment-617702160)**

The export constant has been renamed to 'export-import' as it is more intuitive
if one uses the same endpoint for doing both, the export and the import. Also, a
'queue' constant has been added where long running tasks can be queried by their
task uuid.

Der Endpoint ist für Confluence gedacht, die Konstanten sollten aber auch generisch genug sein für Jira oder Bitbucket.

Folgende Endpoints sollen damit umgesetzt werden:

`GET /export-import`

* `201 (Created)` Synchroner Export, Download URL wird im Location Header zurückgegeben
* `202 (Accepted)` Asynchroner Export, Queue URL wird im Location Header zurückgegeben
* diverse Fehlercodes sonst

`PUT /export-import`

* `201 (Created)` Synchroner Import, Space URL wird im Location Header zurückgegeben
* `202 (Accepted)` Asynchroner Import, Queue URL wird im Location Header zurückgegeben
* diverse Fehlercodes sonst

`GET /export-import/queue/{uuid}`

* `200 (Ok)` Task läuft noch, gib nützliche Infos wie ETA zurück
* `201 (Created)` Download URL wird im Location Header zurückgegeben (Export) / Space URL wird im Location Header zurückgegeben (Import)
* diverse Fehlercodes sonst

Ob ein Export / Import synchron oder asynchron durchgeführt wird, hängt davon ab, ob die Instanz asynchrone Tasks unterstützt. Der Import wäre für mich eher ein POST, aber POST führt im Zusammenspiel mit dem Mediatype `multipart/form-data` immer zu fehlgeschlagener XSRF Prüfung. Das Botron Configuration Manager für Jira verwendet bei ihren Exporten / Importen (deshalb?) auch PUT für die Uploads / Imports.

Etwas unsicher bin ich mir, ob wir zum Abfragen des Tasks für Exporte UND Importe den selben Endpoint `queue` nehmen sollten. Aber der Parameter ist derselbe (`uuid`) und auch die Rückgabe ist dieselbe (Created mit Location Header zum erstellten "Objekt").