### PR TITLE
Define bean naming conventions, add tests, fixes

### DIFF
--- a/doc/CODE_CONVENTIONS.adoc
+++ b/doc/CODE_CONVENTIONS.adoc
@@ -2,6 +2,8 @@
 
 The code conventions are valid for all ConfAPI projects for now.
 
+:toc:
+
 == Naming and Structure
 
 === Quick Reference
@@ -16,11 +18,75 @@ The code conventions are valid for all ConfAPI projects for now.
 
 === Model
 
+We are using [Lombok](https://projectlombok.org/) for generating constructors, getters and setters.
+They always have to be annotated with the `@Data` annotation.
 
+The `@XmlRootElement` should always be named by a constant defined in the `ConfAPI` class.
 
 ==== Entities
 
+Entity beans should only use the `@NoArgsConstructor` to make sure reordering, adding and removing member variables does
+not break the build or behaviour of any dependent because the parametrized constructor was used to create instances.
 
+Example:
+
+[source]
+----
+@Data
+@NoArgsConstructor
+@XmlRootElement(name = ConfAPI.ENTITY)
+public class EntityBean {
+
+    @XmlElement
+    @NotNull
+    private String name;
+
+    @XmlElement
+    private String description;
+
+}
+----
+
+Please note that the constant `ConfAPI.ENTITY` defines a string `entity`.
+The name of the model class has to match the name of that constant.
+
+Be careful with using validators like `@NotNull`.
+Make sure that the attribute really has to be set in all possible cases when you use it.
+
+Whenever necessary, the auto-generated methods may be overridden manually to enforce a specific behaviour.
+For example, if you want to make sure that an empty description is considered null, you may add:
+
+[source]
+----
+    public String getDescription() {
+        if (StringUtils.isNotBlank(description)) {
+            return description;
+        }
+
+        return null;
+    }
+----
+
+==== Entity Collections
+
+We use entity collection beans to hold a collection of entity beans and to specify the return type when the REST API
+returns such a collection.
+
+Thus, there is always only a single attribute necessary which allows using an `@AllArgsConstructor`.
+The pattern of an entity collection always looks like this:
+
+[source]
+----
+@Data
+@AllArgsConstructor
+@XmlRootElement(name = ConfAPI.ENTITIES)
+public class EntitiesBean {
+
+    @XmlElement
+    private Collection<EntityBean> entities;
+
+}
+----
 
 === Resource Interface
 
@@ -34,9 +100,9 @@ actually represent entities at all.
 Examples:
 
 * `MailServerResource`: While technically possible, we only allow setting a single (default) incoming and a single
-  (default) outgoing mail server. Thus, we named the common endpoint only `/mail-server`.
+(default) outgoing mail server. Thus, we named the common endpoint only `/mail-server`.
 * `SettingsResource`: Although we named the endpoint in a plural form, there is only one set of attributes that can be
-  set - one title, one base-url etc. We think that `/settings` just sounds more intuitive than `/setting`.
+set - one title, one base-url etc. We think that `/settings` just sounds more intuitive than `/setting`.
 * The upcoming endpoint for exports and imports.
 
 Whenever it makes sense, the resource interface should be defined in the ConfAPI Commons library, so we can define a
@@ -148,6 +214,4 @@ public class EntitiesResourceImpl implements EntitiesResource {
         }
         return Response.status(BAD_REQUEST).entity(errorCollection).build();
     }
-
-}
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
         <atlassian-user.version>3.0</atlassian-user.version>
         <commons-lang3.version>3.9</commons-lang3.version>
+        <guava.version>29.0-jre</guava.version>
         <hamcrest.version>2.2</hamcrest.version>
         <hibernate-validator.version>5.2.1.Final</hibernate-validator.version>
         <javax.el-api.version>2.2.4</javax.el-api.version>
@@ -195,6 +196,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- needs to be of scope 'provided' as implicitly used for 'checkNotNull' -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- test dependencies -->
 
         <dependency>
@@ -259,6 +268,7 @@
             <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/de/aservo/atlassian/confapi/model/ApplicationLinkBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/ApplicationLinkBean.java
@@ -22,7 +22,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 /**
- * Bean for licence infos in REST requests.
+ * Bean for an application link in REST requests.
  */
 @Data
 @NoArgsConstructor

--- a/src/main/java/de/aservo/atlassian/confapi/model/LicenseBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/LicenseBean.java
@@ -12,7 +12,7 @@ import java.util.Collections;
 import java.util.Date;
 
 /**
- * Bean for licence infos in REST requests.
+ * Bean for a licence info in REST requests.
  */
 @Data
 @NoArgsConstructor

--- a/src/main/java/de/aservo/atlassian/confapi/model/LicensesBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/LicensesBean.java
@@ -10,7 +10,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Collection;
 
 /**
- * Bean for licences infos in REST requests.
+ * Bean for licences info in REST requests.
  */
 @Data
 @NoArgsConstructor

--- a/src/main/java/de/aservo/atlassian/confapi/model/MailServerPopBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/MailServerPopBean.java
@@ -4,15 +4,15 @@ import com.atlassian.mail.server.PopMailServer;
 import de.aservo.atlassian.confapi.constants.ConfAPI;
 import de.aservo.atlassian.confapi.exception.NoContentException;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
 @Data
 @NoArgsConstructor
-@XmlRootElement(name = ConfAPI.MAIL_SERVER_POP)
+@EqualsAndHashCode(callSuper = true)
+@XmlRootElement(name = ConfAPI.MAIL_SERVER + "-" + ConfAPI.MAIL_SERVER_POP)
 public class MailServerPopBean extends AbstractMailServerProtocolBean {
 
     public static MailServerPopBean from(
@@ -31,17 +31,6 @@ public class MailServerPopBean extends AbstractMailServerProtocolBean {
         mailServerPopBean.setTimeout(popMailServer.getTimeout());
         mailServerPopBean.setUsername(popMailServer.getUsername());
         return mailServerPopBean;
-    }
-
-    @Override
-    public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
-    }
-
-    @Override
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o);
     }
 
 }

--- a/src/main/java/de/aservo/atlassian/confapi/model/MailServerSmtpBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/MailServerSmtpBean.java
@@ -4,16 +4,16 @@ import com.atlassian.mail.server.SMTPMailServer;
 import de.aservo.atlassian.confapi.constants.ConfAPI;
 import de.aservo.atlassian.confapi.exception.NoContentException;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @Data
 @NoArgsConstructor
-@XmlRootElement(name = ConfAPI.MAIL_SERVER_SMTP)
+@EqualsAndHashCode(callSuper = true)
+@XmlRootElement(name = ConfAPI.MAIL_SERVER + "-" + ConfAPI.MAIL_SERVER_SMTP)
 public class MailServerSmtpBean extends AbstractMailServerProtocolBean {
 
     @XmlElement
@@ -67,17 +67,6 @@ public class MailServerSmtpBean extends AbstractMailServerProtocolBean {
         mailServerSmtpBean.setTimeout(smtpMailServer.getTimeout());
         mailServerSmtpBean.setUsername(smtpMailServer.getUsername());
         return mailServerSmtpBean;
-    }
-
-    @Override
-    public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
-    }
-
-    @Override
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o);
     }
 
 }

--- a/src/test/java/de/aservo/atlassian/confapi/junit/AbstractBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/junit/AbstractBeanTest.java
@@ -1,0 +1,31 @@
+package de.aservo.atlassian.confapi.junit;
+
+import com.google.common.base.CaseFormat;
+import org.junit.Test;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import static org.junit.Assert.*;
+
+public abstract class AbstractBeanTest extends AbstractTest {
+
+    private static final String CLASS_SUFFIX = "Bean";
+
+    @Test
+    public void beanClassNameShouldEndWithSuffixBean() {
+        final String beanClassName = getBaseClass().getSimpleName();
+        assertTrue("The model class name should end with suffix " + CLASS_SUFFIX,
+                beanClassName.endsWith(CLASS_SUFFIX));
+    }
+
+    @Test
+    public void beanClassNameAndXmlRootElementShouldMatch() {
+        final String beanClassName = getBaseClass().getSimpleName();
+        final String beanClassBaseName = beanClassName.substring(0, beanClassName.length() - CLASS_SUFFIX.length());
+        final XmlRootElement xmlRootElement = getBaseClass().getAnnotation(XmlRootElement.class);
+        assertNotNull(xmlRootElement);
+        assertEquals("The model class camel-case base name and the xml root element kebab-case base name should match",
+                CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, beanClassBaseName), xmlRootElement.name());
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confapi/junit/AbstractTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/junit/AbstractTest.java
@@ -1,0 +1,37 @@
+package de.aservo.atlassian.confapi.junit;
+
+import static de.aservo.atlassian.confapi.util.StringUtil.baseName;
+import static org.junit.Assert.assertTrue;
+
+public abstract class AbstractTest {
+
+    private static final String TEST_CLASS_SUFFIX = "Test";
+
+    private Class<?> baseClass = null;
+
+    public Class<?> getBaseClass() {
+        if (baseClass == null) {
+            baseClass = findBaseClass();
+        }
+
+        return baseClass;
+    }
+
+    private Class<?> findBaseClass() {
+        final String testClassName = getClass().getCanonicalName();
+        assertTrue("The test class should end with suffix Test",
+                testClassName.endsWith(TEST_CLASS_SUFFIX));
+
+        final Class<?> baseClass;
+        final String baseClassName = baseName(testClassName, TEST_CLASS_SUFFIX);
+
+        try {
+            baseClass = Class.forName(baseClassName);
+        } catch (ClassNotFoundException ignored) {
+            throw new AssertionError("The base class of this test should be named " + baseClassName);
+        }
+
+        return baseClass;
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confapi/model/ApplicationLinkBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/ApplicationLinkBeanTest.java
@@ -13,6 +13,7 @@ import com.atlassian.applinks.api.application.refapp.RefAppApplicationType;
 import com.atlassian.applinks.spi.link.ApplicationLinkDetails;
 import com.atlassian.settings.setup.DefaultApplicationLink;
 import com.atlassian.settings.setup.DefaultApplicationType;
+import de.aservo.atlassian.confapi.junit.AbstractBeanTest;
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,7 +29,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ApplicationLinkBeanTest {
+public class ApplicationLinkBeanTest extends AbstractBeanTest {
 
     @Test
     public void testParameterConstructor() throws URISyntaxException {
@@ -104,4 +105,5 @@ public class ApplicationLinkBeanTest {
         ApplicationLink applicationLink = new DefaultApplicationLink(applicationId, applicationType, "test", uri, uri, false, false);
         new ApplicationLinkBean(applicationLink);
     }
+
 }

--- a/src/test/java/de/aservo/atlassian/confapi/model/DirectoryBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/DirectoryBeanTest.java
@@ -3,6 +3,7 @@ package de.aservo.atlassian.confapi.model;
 import com.atlassian.crowd.embedded.api.Directory;
 import com.atlassian.crowd.embedded.api.DirectoryType;
 import com.atlassian.crowd.model.directory.DirectoryImpl;
+import de.aservo.atlassian.confapi.junit.AbstractBeanTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -13,7 +14,7 @@ import static com.atlassian.crowd.directory.RemoteCrowdDirectory.*;
 import static org.junit.Assert.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class DirectoryBeanTest {
+public class DirectoryBeanTest extends AbstractBeanTest {
 
     @Test
     public void testBuildDirectoryImpl() {
@@ -71,4 +72,5 @@ public class DirectoryBeanTest {
         assertEquals(attributes.get(CROWD_HTTP_PROXY_USERNAME), directoryBean.getProxyUsername());
         assertNull(directoryBean.getProxyPassword());
     }
+
 }

--- a/src/test/java/de/aservo/atlassian/confapi/model/LicenseBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/LicenseBeanTest.java
@@ -1,6 +1,7 @@
 package de.aservo.atlassian.confapi.model;
 
 import com.atlassian.sal.api.license.SingleProductLicenseDetailsView;
+import de.aservo.atlassian.confapi.junit.AbstractBeanTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -10,7 +11,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
-public class LicenseBeanTest {
+public class LicenseBeanTest extends AbstractBeanTest {
 
     @Test
     public void testParameterConstructor() {

--- a/src/test/java/de/aservo/atlassian/confapi/model/LicensesBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/LicensesBeanTest.java
@@ -1,6 +1,7 @@
 package de.aservo.atlassian.confapi.model;
 
 import com.atlassian.sal.api.license.SingleProductLicenseDetailsView;
+import de.aservo.atlassian.confapi.junit.AbstractBeanTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -11,7 +12,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
-public class LicensesBeanTest {
+public class LicensesBeanTest extends AbstractBeanTest {
 
     @Test
     public void testParameterConstructor() {
@@ -23,4 +24,5 @@ public class LicensesBeanTest {
         licensesBean.setLicenses(Collections.singletonList(licenseBean));
         assertNotNull(licensesBean.getLicenses());
     }
+
 }

--- a/src/test/java/de/aservo/atlassian/confapi/model/MailServerPopBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/MailServerPopBeanTest.java
@@ -2,6 +2,7 @@ package de.aservo.atlassian.confapi.model;
 
 import com.atlassian.mail.server.DefaultTestPopMailServerImpl;
 import com.atlassian.mail.server.PopMailServer;
+import de.aservo.atlassian.confapi.junit.AbstractBeanTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -11,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(MockitoJUnitRunner.class)
-public class MailServerPopBeanTest {
+public class MailServerPopBeanTest extends AbstractBeanTest {
 
     @Test
     public void testDefaultConstructor() {

--- a/src/test/java/de/aservo/atlassian/confapi/model/MailServerSmtpBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/MailServerSmtpBeanTest.java
@@ -2,6 +2,7 @@ package de.aservo.atlassian.confapi.model;
 
 import com.atlassian.mail.server.DefaultTestSmtpMailServerImpl;
 import com.atlassian.mail.server.SMTPMailServer;
+import de.aservo.atlassian.confapi.junit.AbstractBeanTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -10,7 +11,7 @@ import static com.atlassian.mail.MailConstants.DEFAULT_TIMEOUT;
 import static org.junit.Assert.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class MailServerSmtpBeanTest {
+public class MailServerSmtpBeanTest extends AbstractBeanTest {
 
     @Test
     public void testDefaultConstructor() {

--- a/src/test/java/de/aservo/atlassian/confapi/model/SettingsBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/SettingsBeanTest.java
@@ -2,6 +2,7 @@ package de.aservo.atlassian.confapi.model;
 
 import com.atlassian.mail.server.DefaultTestSmtpMailServerImpl;
 import com.atlassian.mail.server.SMTPMailServer;
+import de.aservo.atlassian.confapi.junit.AbstractBeanTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -10,7 +11,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SettingsBeanTest {
+public class SettingsBeanTest extends AbstractBeanTest {
 
     @Test
     public void testDefaultConstructor() {

--- a/src/test/java/de/aservo/atlassian/confapi/model/UserBeanTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/model/UserBeanTest.java
@@ -1,6 +1,7 @@
 package de.aservo.atlassian.confapi.model;
 
 import com.atlassian.user.impl.DefaultUser;
+import de.aservo.atlassian.confapi.junit.AbstractBeanTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -8,7 +9,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.junit.Assert.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class UserBeanTest {
+public class UserBeanTest extends AbstractBeanTest {
 
     @Test
     public void testParameterConstructor() {

--- a/src/test/java/de/aservo/atlassian/confapi/util/StringUtil.java
+++ b/src/test/java/de/aservo/atlassian/confapi/util/StringUtil.java
@@ -1,0 +1,15 @@
+package de.aservo.atlassian.confapi.util;
+
+public class StringUtil {
+
+    public static String baseName(
+            final String name,
+            final String suffix) {
+
+        return name.substring(0, name.length() - suffix.length());
+    }
+
+    private StringUtil() {
+    }
+
+}


### PR DESCRIPTION
This commit is the first step in defining the naming convention for the ConfAPI
artifacts. It defines how the model beans have to be named and provides
automated tests for checking these naming conventions just by extending from the
AbstractBeanTest class in the bean's test class.

This commit also includes some smaller fixes in comments or regarding
standardization.