### PR TITLE
Move resource implementation to ConfAPI Commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>de.aservo.atlassian</groupId>
     <artifactId>confapi-commons</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ConfAPI Commons</name>

--- a/src/main/java/de/aservo/atlassian/confapi/rest/AbstractDirectoriesResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confapi/rest/AbstractDirectoriesResourceImpl.java
@@ -1,0 +1,56 @@
+package de.aservo.atlassian.confapi.rest;
+
+import de.aservo.atlassian.confapi.model.DirectoriesBean;
+import de.aservo.atlassian.confapi.model.DirectoryBean;
+import de.aservo.atlassian.confapi.model.ErrorCollection;
+import de.aservo.atlassian.confapi.rest.api.DirectoriesResource;
+import de.aservo.atlassian.confapi.service.api.DirectoryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.ws.rs.core.Response;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+
+public abstract class AbstractDirectoriesResourceImpl implements DirectoriesResource {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractDirectoriesResourceImpl.class);
+
+    private final DirectoryService directoryService;
+
+    public AbstractDirectoriesResourceImpl(DirectoryService directoryService) {
+        this.directoryService = checkNotNull(directoryService);
+    }
+
+    @Override
+    public Response getDirectories() {
+        final ErrorCollection errorCollection = new ErrorCollection();
+        try {
+            final DirectoriesBean directoriesBean = new DirectoriesBean(directoryService.getDirectories());
+            return Response.ok(directoriesBean).build();
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            errorCollection.addErrorMessage(e.getMessage());
+        }
+        return Response.status(BAD_REQUEST).entity(errorCollection).build();
+    }
+
+    @Override
+    public Response setDirectory(
+            final boolean testConnection,
+            @Nonnull final DirectoryBean directory) {
+
+        final ErrorCollection errorCollection = new ErrorCollection();
+        try {
+            DirectoryBean addDirectory = directoryService.addDirectory(directory, testConnection);
+            return Response.ok(addDirectory).build();
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            errorCollection.addErrorMessage(e.getMessage());
+        }
+        return Response.status(BAD_REQUEST).entity(errorCollection).build();
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/rest/AbstractPingResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confapi/rest/AbstractPingResourceImpl.java
@@ -1,0 +1,14 @@
+package de.aservo.atlassian.confapi.rest;
+
+import de.aservo.atlassian.confapi.rest.api.PingResource;
+
+import javax.ws.rs.core.Response;
+
+public abstract class AbstractPingResourceImpl implements PingResource {
+
+    @Override
+    public Response getPing() {
+        return Response.ok(PONG).build();
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/rest/api/DirectoriesResource.java
+++ b/src/main/java/de/aservo/atlassian/confapi/rest/api/DirectoriesResource.java
@@ -10,13 +10,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 public interface DirectoriesResource {
 
     @GET
+    @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.DIRECTORIES },
             summary = "Get the list of user directories",
@@ -28,17 +34,19 @@ public interface DirectoriesResource {
     Response getDirectories();
 
     @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.DIRECTORIES },
-            summary = "Add a new directory",
+            summary = "Set a new directory",
             description = "Any existing directory with the same name will be removed before adding the new one",
             responses = {
                     @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = DirectoryBean.class))),
                     @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
             }
     )
-    Response addDirectory(
-            boolean testConnection,
+    Response setDirectory(
+            @QueryParam("test-connection") @DefaultValue("false") final boolean testConnection,
             @NotNull final DirectoryBean directory);
 
 }

--- a/src/main/java/de/aservo/atlassian/confapi/rest/api/PingResource.java
+++ b/src/main/java/de/aservo/atlassian/confapi/rest/api/PingResource.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import javax.ws.rs.GET;
-import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -15,6 +14,7 @@ public interface PingResource {
     String PONG = "pong";
 
     @GET
+    @Produces(MediaType.TEXT_PLAIN)
     @Operation(
             tags = {ConfAPI.PING},
             summary = "Simple ping method for probing the REST api. Returns 'pong' upon success",

--- a/src/test/java/de/aservo/atlassian/confapi/rest/AbstractDirectoriesResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/rest/AbstractDirectoriesResourceTest.java
@@ -1,0 +1,99 @@
+package de.aservo.atlassian.confapi.rest;
+
+import com.atlassian.crowd.embedded.api.Directory;
+import com.atlassian.crowd.embedded.api.DirectoryType;
+import com.atlassian.crowd.exception.DirectoryCurrentlySynchronisingException;
+import com.atlassian.crowd.model.directory.DirectoryImpl;
+import de.aservo.atlassian.confapi.model.DirectoriesBean;
+import de.aservo.atlassian.confapi.model.DirectoryBean;
+import de.aservo.atlassian.confapi.model.ErrorCollection;
+import de.aservo.atlassian.confapi.service.api.DirectoryService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractDirectoriesResourceTest {
+
+    @Mock
+    private DirectoryService directoryService;
+
+    private TestDirectoriesResourceImpl resource;
+
+    @Before
+    public void setup() {
+        resource = new TestDirectoriesResourceImpl(directoryService);
+    }
+
+    @Test
+    public void testGetDirectories() {
+        Directory directory = createDirectory();
+        DirectoryBean initialDirectoryBean = DirectoryBean.from(directory);
+
+        doReturn(Collections.singletonList(initialDirectoryBean)).when(directoryService).getDirectories();
+
+        final Response response = resource.getDirectories();
+        assertEquals(200, response.getStatus());
+        @SuppressWarnings("unchecked") final DirectoriesBean directoriesBean = (DirectoriesBean) response.getEntity();
+
+        assertEquals(initialDirectoryBean, directoriesBean.getDirectories().iterator().next());
+    }
+
+    @Test
+    public void testGetDirectoriesWithError() {
+        doThrow(new RuntimeException()).when(directoryService).getDirectories();
+
+        final Response response = resource.getDirectories();
+        assertEquals(400, response.getStatus());
+
+        assertNotNull(response.getEntity());
+        assertEquals(ErrorCollection.class, response.getEntity().getClass());
+    }
+
+    @Test
+    public void testAddDirectory() throws DirectoryCurrentlySynchronisingException {
+        Directory directory = createDirectory();
+        DirectoryBean directoryBean = DirectoryBean.from(directory);
+        directoryBean.setCrowdUrl("http://localhost");
+        directoryBean.setClientName("confluence-client");
+        directoryBean.setAppPassword("test");
+
+        doReturn(directoryBean).when(directoryService).addDirectory(directoryBean, false);
+
+        final Response response = resource.setDirectory(Boolean.FALSE, directoryBean);
+        assertEquals(200, response.getStatus());
+        final DirectoryBean DirectoryBean = (DirectoryBean) response.getEntity();
+
+        assertEquals(DirectoryBean.getName(), directoryBean.getName());
+    }
+
+    @Test
+    public void testAddDirectoryWithError() throws DirectoryCurrentlySynchronisingException {
+        Directory directory = createDirectory();
+        DirectoryBean directoryBean = DirectoryBean.from(directory);
+        directoryBean.setCrowdUrl("http://localhost");
+        directoryBean.setClientName("confluence-client");
+        directoryBean.setAppPassword("test");
+        doThrow(new DirectoryCurrentlySynchronisingException(1L)).when(directoryService).addDirectory(directoryBean, false);
+
+        final Response response = resource.setDirectory(Boolean.FALSE, directoryBean);
+        assertEquals(400, response.getStatus());
+
+        assertNotNull(response.getEntity());
+        assertEquals(ErrorCollection.class, response.getEntity().getClass());
+    }
+
+    private Directory createDirectory() {
+        return new DirectoryImpl("test", DirectoryType.CROWD, "test.class");
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confapi/rest/AbstractPingResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/rest/AbstractPingResourceTest.java
@@ -1,0 +1,32 @@
+package de.aservo.atlassian.confapi.rest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.ws.rs.core.Response;
+
+import static de.aservo.atlassian.confapi.rest.api.PingResource.PONG;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractPingResourceTest {
+
+    private AbstractPingResourceImpl pingResource;
+
+    @Before
+    public void setup() {
+        // we can use mock with CALLS_REAL_METHODS here because PingResource uses no services
+        pingResource = mock(AbstractPingResourceImpl.class, CALLS_REAL_METHODS);
+    }
+
+    @Test
+    public void testGetPing() {
+        final Response pingResponse = pingResource.getPing();
+        assertEquals(PONG, pingResponse.getEntity().toString());
+    }
+
+}

--- a/src/test/java/de/aservo/atlassian/confapi/rest/TestDirectoriesResourceImpl.java
+++ b/src/test/java/de/aservo/atlassian/confapi/rest/TestDirectoriesResourceImpl.java
@@ -1,0 +1,11 @@
+package de.aservo.atlassian.confapi.rest;
+
+import de.aservo.atlassian.confapi.service.api.DirectoryService;
+
+public class TestDirectoriesResourceImpl extends AbstractDirectoriesResourceImpl {
+
+    public TestDirectoriesResourceImpl(DirectoryService directoryService) {
+        super(directoryService);
+    }
+
+}


### PR DESCRIPTION
During the process of standardizing the ConfAPI plugins, more and more of the
REST and the underlying service interfaces have moved to the Commons library.
This lead to the current state that the actual (default) implementation of the
resources also can be moved to the Commons library, while the actual service
implementations should be moved (back) to the actual plugins in order to get rid
of fixed Atlassian dependencies in the Commons library (see #13).

This commit contains two PoC's for REST resources that are now implemented in
the Commons library. First the PingResource that does not contain any services
at all and second the DirectoriesResource that uses a custom service only.

While the DirectoryService interface will stay in the Commons library, the
DirectoryServiceImpl will be moved to the actual plugins after.

In order to use one of the here implemented in an actual plugin, the developer
only needs to extend from the Abstract<Entity>ResourceImpl, inject the
service(s) and add the corresponding `@Path` to the class.

Snapshot version bump because of interface change in DirectoriesResource.