### PR TITLE
Implement generic web exceptions representing HTTP status codes

### DIFF
--- a/src/main/java/de/aservo/atlassian/confapi/exception/BadRequestException.java
+++ b/src/main/java/de/aservo/atlassian/confapi/exception/BadRequestException.java
@@ -1,0 +1,28 @@
+package de.aservo.atlassian.confapi.exception;
+
+import de.aservo.atlassian.confapi.exception.api.AbstractClientErrorWebException;
+
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+
+public class BadRequestException extends AbstractClientErrorWebException {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+    public BadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BadRequestException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public Response.Status getStatus() {
+        return BAD_REQUEST;
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/exception/InternalServerErrorException.java
+++ b/src/main/java/de/aservo/atlassian/confapi/exception/InternalServerErrorException.java
@@ -1,0 +1,28 @@
+package de.aservo.atlassian.confapi.exception;
+
+import de.aservo.atlassian.confapi.exception.api.AbstractServerErrorWebException;
+
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+
+public class InternalServerErrorException extends AbstractServerErrorWebException {
+
+    public InternalServerErrorException(String message) {
+        super(message);
+    }
+
+    public InternalServerErrorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InternalServerErrorException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public Response.Status getStatus() {
+        return INTERNAL_SERVER_ERROR;
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/exception/NoContentException.java
+++ b/src/main/java/de/aservo/atlassian/confapi/exception/NoContentException.java
@@ -1,11 +1,28 @@
 package de.aservo.atlassian.confapi.exception;
 
-public class NoContentException extends Exception {
+import de.aservo.atlassian.confapi.exception.api.AbstractSuccessWebException;
 
-    public NoContentException(
-            final String message) {
+import javax.ws.rs.core.Response;
 
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+
+public class NoContentException extends AbstractSuccessWebException {
+
+    public NoContentException(String message) {
         super(message);
+    }
+
+    public NoContentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NoContentException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public Response.Status getStatus() {
+        return NO_CONTENT;
     }
 
 }

--- a/src/main/java/de/aservo/atlassian/confapi/exception/NotFoundException.java
+++ b/src/main/java/de/aservo/atlassian/confapi/exception/NotFoundException.java
@@ -1,0 +1,28 @@
+package de.aservo.atlassian.confapi.exception;
+
+import de.aservo.atlassian.confapi.exception.api.AbstractClientErrorWebException;
+
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+public class NotFoundException extends AbstractClientErrorWebException {
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+
+    public NotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public Response.Status getStatus() {
+        return NOT_FOUND;
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/exception/api/AbstractClientErrorWebException.java
+++ b/src/main/java/de/aservo/atlassian/confapi/exception/api/AbstractClientErrorWebException.java
@@ -1,0 +1,17 @@
+package de.aservo.atlassian.confapi.exception.api;
+
+public abstract class AbstractClientErrorWebException extends AbstractWebException {
+
+    public AbstractClientErrorWebException(String message) {
+        super(message);
+    }
+
+    public AbstractClientErrorWebException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AbstractClientErrorWebException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/exception/api/AbstractServerErrorWebException.java
+++ b/src/main/java/de/aservo/atlassian/confapi/exception/api/AbstractServerErrorWebException.java
@@ -1,0 +1,17 @@
+package de.aservo.atlassian.confapi.exception.api;
+
+public abstract class AbstractServerErrorWebException extends AbstractWebException {
+
+    public AbstractServerErrorWebException(String message) {
+        super(message);
+    }
+
+    public AbstractServerErrorWebException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AbstractServerErrorWebException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/exception/api/AbstractSuccessWebException.java
+++ b/src/main/java/de/aservo/atlassian/confapi/exception/api/AbstractSuccessWebException.java
@@ -1,0 +1,17 @@
+package de.aservo.atlassian.confapi.exception.api;
+
+public abstract class AbstractSuccessWebException extends AbstractWebException {
+
+    public AbstractSuccessWebException(String message) {
+        super(message);
+    }
+
+    public AbstractSuccessWebException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AbstractSuccessWebException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/de/aservo/atlassian/confapi/exception/api/AbstractWebException.java
+++ b/src/main/java/de/aservo/atlassian/confapi/exception/api/AbstractWebException.java
@@ -1,0 +1,21 @@
+package de.aservo.atlassian.confapi.exception.api;
+
+import javax.ws.rs.core.Response;
+
+public abstract class AbstractWebException extends Exception {
+
+    public AbstractWebException(String message) {
+        super(message);
+    }
+
+    public AbstractWebException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AbstractWebException(Throwable cause) {
+        super(cause);
+    }
+
+    public abstract Response.Status getStatus();
+
+}

--- a/src/test/java/de/aservo/atlassian/confapi/exception/BadRequestExceptionTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/exception/BadRequestExceptionTest.java
@@ -2,6 +2,6 @@ package de.aservo.atlassian.confapi.exception;
 
 import de.aservo.atlassian.confapi.junit.AbstractWebExceptionTest;
 
-public class NoContentExceptionTest extends AbstractWebExceptionTest {
+public class BadRequestExceptionTest extends AbstractWebExceptionTest {
 
 }

--- a/src/test/java/de/aservo/atlassian/confapi/exception/InternalServerErrorExceptionTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/exception/InternalServerErrorExceptionTest.java
@@ -2,6 +2,6 @@ package de.aservo.atlassian.confapi.exception;
 
 import de.aservo.atlassian.confapi.junit.AbstractWebExceptionTest;
 
-public class NoContentExceptionTest extends AbstractWebExceptionTest {
+public class InternalServerErrorExceptionTest extends AbstractWebExceptionTest {
 
 }

--- a/src/test/java/de/aservo/atlassian/confapi/exception/NotFoundExceptionTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/exception/NotFoundExceptionTest.java
@@ -2,6 +2,6 @@ package de.aservo.atlassian.confapi.exception;
 
 import de.aservo.atlassian.confapi.junit.AbstractWebExceptionTest;
 
-public class NoContentExceptionTest extends AbstractWebExceptionTest {
+public class NotFoundExceptionTest extends AbstractWebExceptionTest {
 
 }

--- a/src/test/java/de/aservo/atlassian/confapi/junit/AbstractWebExceptionTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/junit/AbstractWebExceptionTest.java
@@ -1,0 +1,82 @@
+package de.aservo.atlassian.confapi.junit;
+
+import de.aservo.atlassian.confapi.exception.api.AbstractClientErrorWebException;
+import de.aservo.atlassian.confapi.exception.api.AbstractServerErrorWebException;
+import de.aservo.atlassian.confapi.exception.api.AbstractSuccessWebException;
+import de.aservo.atlassian.confapi.exception.api.AbstractWebException;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.junit.Assert.*;
+
+public abstract class AbstractWebExceptionTest extends AbstractTest {
+
+    private static final String MESSAGE = "message";
+    private static final String THROWABLE_MESSAGE = "throwable-message";
+    private static final Throwable THROWABLE = new Throwable(THROWABLE_MESSAGE);
+
+    @Test
+    public void testParentClassMatchesStatusCodeCategory() throws NoSuchMethodException {
+        final Class<?> baseClass = getBaseClass();
+        final Constructor<?> constructor = getBaseClass().getConstructor(String.class);
+
+        final AbstractWebException exception;
+        try {
+            exception = (AbstractWebException) constructor.newInstance(MESSAGE);
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            fail("The web exception should inherit from one of AbstractWebException's subclasses");
+            return;
+        }
+
+        final Response.Status.Family exceptionStatusFamily = exception.getStatus().getFamily();
+
+        if (AbstractSuccessWebException.class.isAssignableFrom(baseClass)) {
+            assertEquals("The success web exception status code family should be SUCCESSFUL",
+                    Response.Status.Family.SUCCESSFUL, exceptionStatusFamily);
+
+        } else if (AbstractClientErrorWebException.class.isAssignableFrom(baseClass)) {
+            assertEquals("The client error web exception status code family should be CLIENT_ERROR",
+                    Response.Status.Family.CLIENT_ERROR, exceptionStatusFamily);
+
+        } else if (AbstractServerErrorWebException.class.isAssignableFrom(baseClass)) {
+            assertEquals("The server error exception status code family should be SERVER_ERROR",
+                    Response.Status.Family.SERVER_ERROR, exceptionStatusFamily);
+
+        } else if (AbstractWebException.class.isAssignableFrom(baseClass)) {
+            fail("The web exception should not directory inherit from AbstractWebException");
+        }
+    }
+
+    // simple tests to make Sonar happy that constructor behaviour is tested
+
+    @Test
+    public void testMessageConstructor() throws Exception {
+        final Constructor<?> constructor = getBaseClass().getConstructor(String.class);
+        final AbstractWebException exception = (AbstractWebException) constructor.newInstance(MESSAGE);
+
+        assertEquals(MESSAGE, exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    @Test
+    public void testMessageAndThrowableConstructor() throws Exception {
+        final Constructor<?> constructor = getBaseClass().getConstructor(String.class, Throwable.class);
+        final AbstractWebException exception = (AbstractWebException) constructor.newInstance(MESSAGE, THROWABLE);
+
+        assertEquals(MESSAGE, exception.getMessage());
+        assertEquals(THROWABLE, exception.getCause());
+    }
+
+    @Test
+    public void testThrowableConstructor() throws Exception {
+        final Constructor<?> constructor = getBaseClass().getConstructor(Throwable.class);
+        final AbstractWebException exception = (AbstractWebException) constructor.newInstance(THROWABLE);
+
+        assertTrue(exception.getMessage().endsWith(THROWABLE_MESSAGE));
+        assertEquals(THROWABLE, exception.getCause());
+    }
+
+}


### PR DESCRIPTION
These web exceptions will be used to represent different results in the services
classes and replace the currently used Atlassian exceptions.