### PR TITLE
Exclude UserBean password from equals and hashcode

### DIFF
--- a/src/main/java/de/aservo/atlassian/confapi/model/UserBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/UserBean.java
@@ -2,6 +2,7 @@ package de.aservo.atlassian.confapi.model;
 
 import de.aservo.atlassian.confapi.constants.ConfAPI;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -25,6 +26,7 @@ public class UserBean {
     private String email;
 
     @XmlElement
+    @EqualsAndHashCode.Exclude
     private String password;
 
     // Example instances for documentation and tests
@@ -37,6 +39,15 @@ public class UserBean {
         EXAMPLE_1.setFullName("Example User");
         EXAMPLE_1.setEmail("user@example.com");
         EXAMPLE_1.setPassword("3x4mpl3");
+    }
+
+    public static final UserBean EXAMPLE_2;
+
+    static {
+        EXAMPLE_2 = new UserBean();
+        EXAMPLE_2.setUserName("example");
+        EXAMPLE_2.setFullName("Changed Example User");
+        EXAMPLE_2.setEmail("user@new-example.com");
     }
 
 }


### PR DESCRIPTION
Also add another example instance to the model class.