### PR TITLE
license handling classes

### DIFF
--- a/src/main/java/de/aservo/atlassian/confapi/rest/AbstractLicensesResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confapi/rest/AbstractLicensesResourceImpl.java
@@ -1,0 +1,35 @@
+package de.aservo.atlassian.confapi.rest;
+
+import de.aservo.atlassian.confapi.model.LicenseBean;
+import de.aservo.atlassian.confapi.model.LicensesBean;
+import de.aservo.atlassian.confapi.rest.api.LicensesResource;
+import de.aservo.atlassian.confapi.service.api.LicensesService;
+
+import javax.ws.rs.core.Response;
+
+public abstract class AbstractLicensesResourceImpl implements LicensesResource {
+
+    private final LicensesService licensesService;
+
+    public AbstractLicensesResourceImpl(final LicensesService licensesService) {
+        this.licensesService = licensesService;
+    }
+
+    @Override
+    public Response getLicenses() {
+        final LicensesBean licensesBean = licensesService.getLicenses();
+        return Response.ok(licensesBean).build();
+    }
+
+    @Override
+    public Response setLicenses(boolean clear, LicensesBean licensesBean) {
+        LicensesBean updatedLicensesBean = licensesService.setLicenses(clear, licensesBean);
+        return Response.ok(updatedLicensesBean).build();
+    }
+
+    @Override
+    public Response setLicense(boolean clear, LicenseBean licenseBean) {
+        LicensesBean updatedLicensesBean = licensesService.setLicense(clear, licenseBean);
+        return Response.ok(updatedLicensesBean).build();
+    }
+}

--- a/src/main/java/de/aservo/atlassian/confapi/rest/api/LicensesResource.java
+++ b/src/main/java/de/aservo/atlassian/confapi/rest/api/LicensesResource.java
@@ -2,6 +2,7 @@ package de.aservo.atlassian.confapi.rest.api;
 
 import de.aservo.atlassian.confapi.constants.ConfAPI;
 import de.aservo.atlassian.confapi.model.ErrorCollection;
+import de.aservo.atlassian.confapi.model.LicenseBean;
 import de.aservo.atlassian.confapi.model.LicensesBean;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -35,7 +36,23 @@ public interface LicensesResource {
     Response getLicenses();
 
     @PUT
-    @Consumes(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            tags = { ConfAPI.LICENSES },
+            summary = "Set a new set of license",
+            description = "Existing license details are overwritten. Upon successful request, returns a `LicensesBean` object containing license details",
+            responses = {
+                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LicensesBean.class))),
+                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+            }
+    )
+    Response setLicenses(
+            @Parameter(description="Clear license details before updating (Jira only).") @QueryParam ("clear") @DefaultValue("false") final boolean clear,
+            @NotNull final LicensesBean licensesBean);
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.LICENSES },
@@ -48,6 +65,6 @@ public interface LicensesResource {
     )
     Response setLicense(
             @Parameter(description="Clear license details before updating (Jira only).") @QueryParam ("clear") @DefaultValue("false") final boolean clear,
-            @NotNull final String licenseKey);
+            @NotNull final LicenseBean licenseBean);
 
 }

--- a/src/main/java/de/aservo/atlassian/confapi/service/api/LicensesService.java
+++ b/src/main/java/de/aservo/atlassian/confapi/service/api/LicensesService.java
@@ -1,0 +1,39 @@
+package de.aservo.atlassian.confapi.service.api;
+
+import de.aservo.atlassian.confapi.model.LicenseBean;
+import de.aservo.atlassian.confapi.model.LicensesBean;
+
+import javax.validation.constraints.NotNull;
+
+public interface LicensesService {
+
+    /**
+     * Get the licenses.
+     *
+     * @return the licenses
+     */
+    public LicensesBean getLicenses();
+
+
+    /**
+     * Set the licenses
+     *
+     * @param licensesBean the licenses to set
+     * @param clear whether or not to clear all licenses before setting the new ones
+     * @return the licenses
+     */
+    public LicensesBean setLicenses(
+            boolean clear,
+            @NotNull final LicensesBean licensesBean);
+
+    /**
+     * Set a single license
+     *
+     * @param licenseBean the single license to set
+     * @param clear whether or not to clear all licenses before setting the new one
+     * @return the licenses
+     */
+    public LicensesBean setLicense(
+            boolean clear,
+            @NotNull final LicenseBean licenseBean);
+}

--- a/src/test/java/de/aservo/atlassian/confapi/rest/AbstractLicensesResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/rest/AbstractLicensesResourceTest.java
@@ -1,0 +1,69 @@
+package de.aservo.atlassian.confapi.rest;
+
+import de.aservo.atlassian.confapi.model.LicenseBean;
+import de.aservo.atlassian.confapi.model.LicensesBean;
+import de.aservo.atlassian.confapi.service.api.LicensesService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractLicensesResourceTest {
+
+    @Mock
+    private LicensesService licensesService;
+
+    private TestLicensesResourceImpl resource;
+
+    @Before
+    public void setup() {
+        resource = new TestLicensesResourceImpl(licensesService);
+    }
+
+    @Test
+    public void testGetLicenses() {
+        final LicensesBean bean = LicensesBean.EXAMPLE_1;
+
+        doReturn(bean).when(licensesService).getLicenses();
+
+        final Response response = resource.getLicenses();
+        assertEquals(200, response.getStatus());
+        final LicensesBean licensesBean = (LicensesBean) response.getEntity();
+
+        assertEquals(licensesBean, bean);
+    }
+
+    @Test
+    public void testSetLicenses() {
+        final LicensesBean bean = LicensesBean.EXAMPLE_1;
+
+        doReturn(bean).when(licensesService).setLicenses(true, bean);
+
+        final Response response = resource.setLicenses(true, bean);
+        assertEquals(200, response.getStatus());
+        final LicensesBean licensesBean = (LicensesBean) response.getEntity();
+
+        assertEquals(licensesBean, bean);
+    }
+
+    @Test
+    public void testSetLicense() {
+        final LicensesBean beanToReturn = LicensesBean.EXAMPLE_1;
+        final LicenseBean beanArg = beanToReturn.getLicenses().iterator().next();
+
+        doReturn(beanToReturn).when(licensesService).setLicense(true, beanArg);
+
+        final Response response = resource.setLicense(true, beanArg);
+        assertEquals(200, response.getStatus());
+        final LicensesBean licensesBean = (LicensesBean) response.getEntity();
+
+        assertEquals(licensesBean, beanToReturn);
+    }
+}

--- a/src/test/java/de/aservo/atlassian/confapi/rest/TestLicensesResourceImpl.java
+++ b/src/test/java/de/aservo/atlassian/confapi/rest/TestLicensesResourceImpl.java
@@ -1,0 +1,11 @@
+package de.aservo.atlassian.confapi.rest;
+
+import de.aservo.atlassian.confapi.service.api.LicensesService;
+
+public class TestLicensesResourceImpl extends AbstractLicensesResourceImpl {
+
+    public TestLicensesResourceImpl(LicensesService licensesService) {
+        super(licensesService);
+    }
+
+}


### PR DESCRIPTION
This commit contains models and interface for building common licence
REST resources across all ConfAPI plugins. It has been adapted to the
latest confapi-commons interface structure. In addition, licenseKey String
body was replaced with `LicenseBean`. An additional resource for setting
multiople licenses `LicensesBean` was also added. 