### PR TITLE
License resource with addLicense method

### DIFF
--- a/src/main/java/de/aservo/atlassian/confapi/rest/AbstractLicensesResourceImpl.java
+++ b/src/main/java/de/aservo/atlassian/confapi/rest/AbstractLicensesResourceImpl.java
@@ -22,14 +22,14 @@ public abstract class AbstractLicensesResourceImpl implements LicensesResource {
     }
 
     @Override
-    public Response setLicenses(boolean clear, LicensesBean licensesBean) {
-        LicensesBean updatedLicensesBean = licensesService.setLicenses(clear, licensesBean);
+    public Response setLicenses(LicensesBean licensesBean) {
+        LicensesBean updatedLicensesBean = licensesService.setLicenses(licensesBean);
         return Response.ok(updatedLicensesBean).build();
     }
 
     @Override
-    public Response setLicense(boolean clear, LicenseBean licenseBean) {
-        LicensesBean updatedLicensesBean = licensesService.setLicense(clear, licenseBean);
+    public Response addLicense(LicenseBean licenseBean) {
+        LicensesBean updatedLicensesBean = licensesService.setLicense(licenseBean);
         return Response.ok(updatedLicensesBean).build();
     }
 }

--- a/src/main/java/de/aservo/atlassian/confapi/rest/api/LicensesResource.java
+++ b/src/main/java/de/aservo/atlassian/confapi/rest/api/LicensesResource.java
@@ -5,18 +5,16 @@ import de.aservo.atlassian.confapi.model.ErrorCollection;
 import de.aservo.atlassian.confapi.model.LicenseBean;
 import de.aservo.atlassian.confapi.model.LicensesBean;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -41,30 +39,27 @@ public interface LicensesResource {
     @Operation(
             tags = { ConfAPI.LICENSES },
             summary = "Set a new set of license",
-            description = "Existing license details are overwritten. Upon successful request, returns a `LicensesBean` object containing license details",
+            description = "Existing license details are always cleared before setting the new licenses. Upon successful request, returns a `LicensesBean` object containing license details",
             responses = {
                     @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LicensesBean.class))),
                     @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
             }
     )
     Response setLicenses(
-            @Parameter(description="Clear license details before updating (Jira only).") @QueryParam ("clear") @DefaultValue("false") final boolean clear,
             @NotNull final LicensesBean licensesBean);
 
-    @PUT
+    @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.LICENSES },
-            summary = "Set a new license",
-            description = "Existing license details are overwritten. Upon successful request, returns a `LicensesBean` object containing license details",
+            summary = "Adds a single license",
+            description = "Upon successful request, returns a `LicensesBean` object containing license details",
             responses = {
                     @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LicensesBean.class))),
                     @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
             }
     )
-    Response setLicense(
-            @Parameter(description="Clear license details before updating (Jira only).") @QueryParam ("clear") @DefaultValue("false") final boolean clear,
+    Response addLicense(
             @NotNull final LicenseBean licenseBean);
-
 }

--- a/src/main/java/de/aservo/atlassian/confapi/service/api/LicensesService.java
+++ b/src/main/java/de/aservo/atlassian/confapi/service/api/LicensesService.java
@@ -19,21 +19,17 @@ public interface LicensesService {
      * Set the licenses
      *
      * @param licensesBean the licenses to set
-     * @param clear whether or not to clear all licenses before setting the new ones
      * @return the licenses
      */
     public LicensesBean setLicenses(
-            boolean clear,
             @NotNull final LicensesBean licensesBean);
 
     /**
      * Set a single license
      *
      * @param licenseBean the single license to set
-     * @param clear whether or not to clear all licenses before setting the new one
      * @return the licenses
      */
     public LicensesBean setLicense(
-            boolean clear,
             @NotNull final LicenseBean licenseBean);
 }

--- a/src/test/java/de/aservo/atlassian/confapi/rest/AbstractLicensesResourceTest.java
+++ b/src/test/java/de/aservo/atlassian/confapi/rest/AbstractLicensesResourceTest.java
@@ -44,9 +44,9 @@ public class AbstractLicensesResourceTest {
     public void testSetLicenses() {
         final LicensesBean bean = LicensesBean.EXAMPLE_1;
 
-        doReturn(bean).when(licensesService).setLicenses(true, bean);
+        doReturn(bean).when(licensesService).setLicenses(bean);
 
-        final Response response = resource.setLicenses(true, bean);
+        final Response response = resource.setLicenses(bean);
         assertEquals(200, response.getStatus());
         final LicensesBean licensesBean = (LicensesBean) response.getEntity();
 
@@ -54,13 +54,13 @@ public class AbstractLicensesResourceTest {
     }
 
     @Test
-    public void testSetLicense() {
+    public void testAddLicense() {
         final LicensesBean beanToReturn = LicensesBean.EXAMPLE_1;
         final LicenseBean beanArg = beanToReturn.getLicenses().iterator().next();
 
-        doReturn(beanToReturn).when(licensesService).setLicense(true, beanArg);
+        doReturn(beanToReturn).when(licensesService).setLicense(beanArg);
 
-        final Response response = resource.setLicense(true, beanArg);
+        final Response response = resource.addLicense(beanArg);
         assertEquals(200, response.getStatus());
         final LicensesBean licensesBean = (LicensesBean) response.getEntity();
 


### PR DESCRIPTION
Due to a resource addressing conflict (path + mediatype) the
license resource was redesigned. Now, there is a dedicated
POST addLicense resource which adds a new license to an already
existing license collection.

The PUT setLicenses resource replaces the existing license
collection.

Because of this redesign the 'clear' flag was removed. Clearing
license details is achieved with the setLicenses method.