### PR TITLE
Abstract integration tests implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>de.aservo.atlassian</groupId>
     <artifactId>confapi-commons</artifactId>
-    <version>0.0.6-SNAPSHOT</version>
+    <version>0.0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ConfAPI Commons</name>
@@ -56,6 +56,7 @@
         <guava.version>29.0-jre</guava.version>
         <hamcrest.version>2.2</hamcrest.version>
         <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
+        <jackson-jaxrs.version>1.9.13-atlassian-5</jackson-jaxrs.version>
         <javax.el-api.version>2.2.4</javax.el-api.version>
         <javax.inject.version>1</javax.inject.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
@@ -69,6 +70,7 @@
         <spring-context.version>5.2.4.RELEASE</spring-context.version>
         <swagger.version>2.1.1</swagger.version>
         <validation-api.version>1.1.0.FINAL</validation-api.version>
+        <wink-client.version>1.4</wink-client.version>
     </properties>
 
     <dependencies>
@@ -209,6 +211,20 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.wink</groupId>
+            <artifactId>wink-client</artifactId>
+            <version>${wink-client.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-jaxrs</artifactId>
+            <version>${jackson-jaxrs.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/de/aservo/atlassian/confapi/model/SettingsBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/SettingsBean.java
@@ -5,13 +5,17 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
 
 @Data
 @NoArgsConstructor
 @XmlRootElement(name = ConfAPI.SETTINGS)
-public class SettingsBean {
+@XmlAccessorType(XmlAccessType.FIELD)
+public class SettingsBean implements Serializable {
 
     @XmlElement
     private String baseUrl;
@@ -33,12 +37,18 @@ public class SettingsBean {
     // Example instances for documentation and tests
 
     public static final SettingsBean EXAMPLE_1;
+    public static final SettingsBean EXAMPLE_1_NO_MODE;
 
     static {
         EXAMPLE_1 = new SettingsBean();
         EXAMPLE_1.setTitle("Example");
         EXAMPLE_1.setBaseUrl("https://example.com");
         EXAMPLE_1.setMode("private");
+
+        EXAMPLE_1_NO_MODE = new SettingsBean();
+        EXAMPLE_1_NO_MODE.setTitle("Example");
+        EXAMPLE_1_NO_MODE.setBaseUrl("https://example.com");
+        EXAMPLE_1_NO_MODE.setMode(null);
     }
 
 }

--- a/src/test/java/it/de/aservo/atlassian/confapi/rest/ClientApplication.java
+++ b/src/test/java/it/de/aservo/atlassian/confapi/rest/ClientApplication.java
@@ -1,0 +1,19 @@
+package it.de.aservo.atlassian.confapi.rest;
+
+import javax.ws.rs.core.Application;
+import java.util.Collections;
+import java.util.Set;
+
+public class ClientApplication extends Application {
+
+    private Set<Object> singletons = Collections.emptySet();
+
+    @Override
+    public Set<Object> getSingletons() {
+        return singletons;
+    }
+
+    public void setSingletons(final Set<Object> singletons) {
+        this.singletons = singletons;
+    }
+}

--- a/src/test/java/it/de/aservo/atlassian/confapi/rest/PingResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/atlassian/confapi/rest/PingResourceFuncTest.java
@@ -1,0 +1,18 @@
+package it.de.aservo.atlassian.confapi.rest;
+
+import de.aservo.atlassian.confapi.constants.ConfAPI;
+import org.apache.wink.client.Resource;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class PingResourceFuncTest {
+
+    @Test
+    public void testGetPing() {
+        Resource pingResource = ResourceBuilder.builder(ConfAPI.PING).build();
+        assertEquals(Response.Status.OK.getStatusCode(), pingResource.get().getStatusCode());
+    }
+}

--- a/src/test/java/it/de/aservo/atlassian/confapi/rest/ResourceBuilder.java
+++ b/src/test/java/it/de/aservo/atlassian/confapi/rest/ResourceBuilder.java
@@ -1,0 +1,78 @@
+package it.de.aservo.atlassian.confapi.rest;
+
+import org.apache.wink.client.ClientConfig;
+import org.apache.wink.client.Resource;
+import org.apache.wink.client.RestClient;
+import org.apache.wink.client.handlers.BasicAuthSecurityHandler;
+import org.codehaus.jackson.jaxrs.JacksonJsonProvider;
+
+import javax.ws.rs.core.MediaType;
+import java.util.Collections;
+
+public class ResourceBuilder {
+
+    private static final String REST_PATH = "/rest/confapi/1/";
+    private final String baseUrl = System.getProperty("baseurl");
+
+    private String username = "admin";
+    private String password = "admin";
+    private String acceptMediaType = MediaType.APPLICATION_JSON;
+    private String contentMediaType = MediaType.APPLICATION_JSON;
+    private final String resourceName;
+
+    private ResourceBuilder(final String resourceName) {
+        this.resourceName = resourceName;
+    }
+
+    public static ResourceBuilder builder(final String resourceName) {
+        return new ResourceBuilder(resourceName);
+    }
+
+    public ResourceBuilder username(final String username) {
+        this.username = username;
+        return this;
+    }
+
+    public ResourceBuilder password(final String password) {
+        this.password = password;
+        return this;
+    }
+
+    public ResourceBuilder acceptMediaType(final String acceptMediaType) {
+        this.acceptMediaType = acceptMediaType;
+        return this;
+    }
+
+    public ResourceBuilder contentMediaType(final String contentMediaType) {
+        this.contentMediaType = contentMediaType;
+        return this;
+    }
+
+    /**
+     * Creates a new REST client for test purposes. Note that the client must be recreated like this for auth tests.
+     * (Atlassian uses cookies for authentication which may survive otherwise and lead to false test results regarding auth)
+     *
+     * @return the built resource
+     */
+    public Resource build() {
+
+        //create new client app with Jackson binding
+        final ClientApplication clientApplication = new ClientApplication();
+        clientApplication.setSingletons(Collections.singleton(new JacksonJsonProvider()));
+        final ClientConfig config = new ClientConfig().applications(clientApplication);
+
+        //setup http basic auth
+        final BasicAuthSecurityHandler basicAuthHandler = new BasicAuthSecurityHandler();
+        basicAuthHandler.setUserName(username);
+        basicAuthHandler.setPassword(password);
+        config.handlers(basicAuthHandler);
+        RestClient restClient = new RestClient(config);
+
+        //configure resource
+        String resourceUrl = baseUrl + REST_PATH + resourceName;
+        Resource resource = restClient.resource(resourceUrl);
+        resource.accept(acceptMediaType);
+        resource.contentType(contentMediaType);
+        return resource;
+    }
+}

--- a/src/test/java/it/de/aservo/atlassian/confapi/rest/SettingsResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/atlassian/confapi/rest/SettingsResourceFuncTest.java
@@ -1,0 +1,77 @@
+package it.de.aservo.atlassian.confapi.rest;
+
+import de.aservo.atlassian.confapi.constants.ConfAPI;
+import de.aservo.atlassian.confapi.model.SettingsBean;
+import org.apache.wink.client.ClientAuthenticationException;
+import org.apache.wink.client.ClientResponse;
+import org.apache.wink.client.Resource;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public abstract class SettingsResourceFuncTest {
+
+    @Test
+    public void testGetSettings() {
+        Resource settingsResource = ResourceBuilder.builder(ConfAPI.SETTINGS).build();
+        ClientResponse clientResponse = settingsResource.get();
+        assertEquals(Response.Status.OK.getStatusCode(), clientResponse.getStatusCode());
+        assertNotNull(clientResponse.getEntity(SettingsBean.class).getTitle());
+    }
+
+    @Test
+    public void testSetSettings() {
+        Resource settingsResource = ResourceBuilder.builder(ConfAPI.SETTINGS).build();
+        assertEquals(Response.Status.OK.getStatusCode(), settingsResource.put(getExampleBean()).getStatusCode());
+
+        ClientResponse clientResponse = settingsResource.get();
+        assertEquals(Response.Status.OK.getStatusCode(), clientResponse.getStatusCode());
+        assertEquals(getExampleBean(), clientResponse.getEntity(SettingsBean.class));
+    }
+
+    @Test(expected = ClientAuthenticationException.class)
+    public void testGetSettingsUnauthenticated() {
+        Resource settingsResource = ResourceBuilder.builder(ConfAPI.SETTINGS)
+                .username("wrong")
+                .password("password")
+                .build();
+        settingsResource.get();
+    }
+
+    @Test(expected = ClientAuthenticationException.class)
+    public void testSetSettingsUnauthenticated() {
+        Resource settingsResource = ResourceBuilder.builder(ConfAPI.SETTINGS)
+                .username("wrong")
+                .password("password")
+                .build();
+        settingsResource.put(getExampleBean());
+    }
+
+    @Test
+    @Ignore("cannot be executed because there is no default user with restricted access rights")
+    public void testGetSettingsUnauthorized() {
+        Resource settingsResource = ResourceBuilder.builder(ConfAPI.SETTINGS)
+                .username("user")
+                .password("user")
+                .build();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), settingsResource.get().getStatusCode());
+    }
+
+    @Test
+    @Ignore("cannot be executed because there is no default user with restricted access rights")
+    public void testSetSettingsUnauthorized() {
+        Resource settingsResource = ResourceBuilder.builder(ConfAPI.SETTINGS)
+                .username("user")
+                .password("user")
+                .build();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), settingsResource.put(getExampleBean()).getStatusCode());
+    }
+
+    protected SettingsBean getExampleBean() {
+        return SettingsBean.EXAMPLE_1;
+    }
+}


### PR DESCRIPTION
This commit introduces abstract integration testing.
Examples are given for 'ping' and 'settings' resources.

The intention is to define all integration tests in the
commons library and only inherit the 'Abstract*ResourceFuncTest'
classes in the actual confapi plugin.