### PR TITLE
Abstract licenses resource integration tests implementation

### DIFF
--- a/src/main/java/de/aservo/atlassian/confapi/model/LicenseBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/LicenseBean.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -42,6 +43,7 @@ public class LicenseBean {
     // Example instances for documentation and tests
 
     public static final LicenseBean EXAMPLE_1;
+    public static final LicenseBean EXAMPLE_2_DEVELOPER_LICENSE;
 
     static {
         EXAMPLE_1 = new LicenseBean();
@@ -51,6 +53,34 @@ public class LicenseBean {
         EXAMPLE_1.setProducts(Collections.singleton("example-product"));
         EXAMPLE_1.setNumUsers(10);
         EXAMPLE_1.setExpiryDate(new Date());
+
+        // use "3 hour expiration for all Atlassian host products*"
+        // from https://developer.atlassian.com/platform/marketplace/timebomb-licenses-for-testing-server-apps/
+        EXAMPLE_2_DEVELOPER_LICENSE = new LicenseBean();
+        EXAMPLE_2_DEVELOPER_LICENSE.setKey(
+                "AAACLg0ODAoPeNqNVEtv4jAQvudXRNpbpUSEx6FIOQBxW3ZZiCB0V1WllXEG8DbYke3A8u/XdUgVQ\n" +
+                "yg9ZvLN+HuM/e1BUHdGlNvuuEHQ73X73Y4bR4nbbgU9ZwFiD2IchcPH+8T7vXzuej9eXp68YSv45\n" +
+                "UwoASYhOeYwxTsIE7RIxtNHhwh+SP3a33D0XnntuxHsIeM5CIdwtvYxUXQPoRIF6KaC0FUGVlEB3\n" +
+                "v0hOAOWYiH9abFbgZith3i34nwOO65gsAGmZBhUbNC/nIpjhBWEcefJWelzqIDPWz/OtjmXRYv2X\n" +
+                "yqwnwueFkT57x8e4cLmbCD1QnX0UoKQoRc4EUgiaK4oZ2ECUrlZeay75sLNs2JDmZtWR8oPCfWZG\n" +
+                "wHAtjzXgIo0SqmZiKYJmsfz8QI5aI+zApuq6fqJKVPAMCPnNpk4LPW6kBWgkZb+kQAzzzS2g6Dnt\n" +
+                "e69Tqvsr4SOskIqEFOeggz1v4zrHbr0yLJR8rU64FpQpVtBy1mZxM4CnHC9Faf8tKMnTF1AiXORF\n" +
+                "ixyQaWto3RZ+ncWLXtMg6EnKZZRpmQNb2R8tnJXFulCfXmXLry7TrHBWn2HNVyH8WYxj9AzmsxiN\n" +
+                "L/R88Xg6rA1lVs4QpO5titxhplJcCY2mFFZLutAZVhKipm15/VhJx36YVqyN8YP7IaGC1+lwnJ7Q\n" +
+                "5pJpNmxk5hP3qovutY8Pi4E2WIJ59esnr1p+T6eD67teBVCHf+ga+ho4/4D9YItZDAsAhQ5qQ6pA\n" +
+                "SJ+SA7YG9zthbLxRoBBEwIURQr5Zy1B8PonepyLz3UhL7kMVEs=X02q6");
+        EXAMPLE_2_DEVELOPER_LICENSE.setDescription("Test license for plugin developers");
+        EXAMPLE_2_DEVELOPER_LICENSE.setLicenseType("TESTING");
+        EXAMPLE_2_DEVELOPER_LICENSE.setOrganization("Atlassian");
+        EXAMPLE_2_DEVELOPER_LICENSE.setProducts(Arrays.asList(
+                "Confluence",
+                "Jira",
+                "Bitbucket",
+                "Crowd",
+                "Bamboo",
+                "Fisheye"));
+        EXAMPLE_2_DEVELOPER_LICENSE.setNumUsers(1);
+        EXAMPLE_2_DEVELOPER_LICENSE.setExpiryDate(new Date());
     }
 
 }

--- a/src/main/java/de/aservo/atlassian/confapi/model/LicensesBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/LicensesBean.java
@@ -25,5 +25,6 @@ public class LicensesBean {
     // Example instances for documentation and tests
 
     public static final LicensesBean EXAMPLE_1 = new LicensesBean(Collections.singleton(LicenseBean.EXAMPLE_1));
+    public static final LicensesBean EXAMPLE_2_DEVELOPER_LICENSE = new LicensesBean(Collections.singleton(LicenseBean.EXAMPLE_2_DEVELOPER_LICENSE));
 
 }

--- a/src/test/java/it/de/aservo/atlassian/confapi/rest/AbstractLicenseResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/atlassian/confapi/rest/AbstractLicenseResourceFuncTest.java
@@ -1,0 +1,100 @@
+package it.de.aservo.atlassian.confapi.rest;
+
+import de.aservo.atlassian.confapi.constants.ConfAPI;
+import de.aservo.atlassian.confapi.model.LicenseBean;
+import de.aservo.atlassian.confapi.model.LicensesBean;
+import org.apache.wink.client.ClientAuthenticationException;
+import org.apache.wink.client.ClientResponse;
+import org.apache.wink.client.Resource;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+public abstract class AbstractLicenseResourceFuncTest {
+
+    @Test
+    public void testGetLicenses() {
+        Resource licensesResource = ResourceBuilder.builder(ConfAPI.LICENSES).build();
+
+        ClientResponse clientResponse = licensesResource.get();
+        assertEquals(Response.Status.OK.getStatusCode(), clientResponse.getStatusCode());
+
+        Collection<LicenseBean> licenses = clientResponse.getEntity(LicensesBean.class).getLicenses();
+        assertNotNull(licenses);
+        assertNotEquals(0, licenses.size());
+        assertNotNull(licenses.iterator().next().getOrganization());
+    }
+
+    @Test
+    public void testSetLicenses() {
+        Resource licensesResource = ResourceBuilder.builder(ConfAPI.LICENSES).build();
+
+        ClientResponse response = licensesResource.put(getExampleBean());
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+
+        response = licensesResource.get();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+        assertEquals(getExampleBean().getLicenses().iterator().next().getDescription(),
+                response.getEntity(LicensesBean.class).getLicenses().iterator().next().getDescription());
+    }
+
+    @Test
+    public void testAddLicenses() {
+        Resource licensesResource = ResourceBuilder.builder(ConfAPI.LICENSES).build();
+
+        LicenseBean licenseBean = getExampleBean().getLicenses().iterator().next();
+        ClientResponse response = licensesResource.post(licenseBean);
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+
+        response = licensesResource.get();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+        assertEquals(licenseBean.getDescription(),
+                response.getEntity(LicensesBean.class).getLicenses().iterator().next().getDescription());
+    }
+
+    @Test(expected = ClientAuthenticationException.class)
+    public void testGetLicensesUnauthenticated() {
+        Resource licensesResource = ResourceBuilder.builder(ConfAPI.LICENSES)
+                .username("wrong")
+                .password("password")
+                .build();
+        licensesResource.get();
+    }
+
+    @Test(expected = ClientAuthenticationException.class)
+    public void testSetLicensesUnauthenticated() {
+        Resource licensesResource = ResourceBuilder.builder(ConfAPI.LICENSES)
+                .username("wrong")
+                .password("password")
+                .build();
+        licensesResource.put(getExampleBean());
+    }
+
+    @Test
+    @Ignore("cannot be executed because there is no default user with restricted access rights")
+    public void testGetLicensesUnauthorized() {
+        Resource licensesResource = ResourceBuilder.builder(ConfAPI.LICENSES)
+                .username("user")
+                .password("user")
+                .build();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), licensesResource.get().getStatusCode());
+    }
+
+    @Test
+    @Ignore("cannot be executed because there is no default user with restricted access rights")
+    public void testSetLicensesUnauthorized() {
+        Resource licensesResource = ResourceBuilder.builder(ConfAPI.LICENSES)
+                .username("user")
+                .password("user")
+                .build();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), licensesResource.put(getExampleBean()).getStatusCode());
+    }
+
+    protected LicensesBean getExampleBean() {
+        return LicensesBean.EXAMPLE_2_DEVELOPER_LICENSE;
+    }
+}

--- a/src/test/java/it/de/aservo/atlassian/confapi/rest/AbstractPingResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/atlassian/confapi/rest/AbstractPingResourceFuncTest.java
@@ -4,15 +4,16 @@ import de.aservo.atlassian.confapi.constants.ConfAPI;
 import org.apache.wink.client.Resource;
 import org.junit.Test;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import static org.junit.Assert.assertEquals;
 
-public abstract class PingResourceFuncTest {
+public abstract class AbstractPingResourceFuncTest {
 
     @Test
     public void testGetPing() {
-        Resource pingResource = ResourceBuilder.builder(ConfAPI.PING).build();
+        Resource pingResource = ResourceBuilder.builder(ConfAPI.PING).acceptMediaType(MediaType.TEXT_PLAIN).build();
         assertEquals(Response.Status.OK.getStatusCode(), pingResource.get().getStatusCode());
     }
 }

--- a/src/test/java/it/de/aservo/atlassian/confapi/rest/AbstractSettingsResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/atlassian/confapi/rest/AbstractSettingsResourceFuncTest.java
@@ -13,7 +13,7 @@ import javax.ws.rs.core.Response;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public abstract class SettingsResourceFuncTest {
+public abstract class AbstractSettingsResourceFuncTest {
 
     @Test
     public void testGetSettings() {


### PR DESCRIPTION
This commit introduces abstract integration testing for the licenses
resource. In addition, a sample LicenseBean with a generic 3h developer
license is provided as well. The key might need to be replaced on
a regular basis.

Also, the abstract classes for 'ping' and 'settings' resource integration
tests were renamed. For ping, the mediatype was corrected to text/plain.