### PR TITLE
Abstract mailserver resource integration tests implementation

### DIFF
--- a/src/main/java/de/aservo/atlassian/confapi/model/MailServerPopBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/MailServerPopBean.java
@@ -16,11 +16,17 @@ public class MailServerPopBean extends AbstractMailServerProtocolBean {
     // Example instances for documentation and tests
 
     public static final MailServerPopBean EXAMPLE_1;
+    public static final MailServerPopBean EXAMPLE_2;
 
     static {
         EXAMPLE_1 = new MailServerPopBean();
         EXAMPLE_1.setName("Example");
         EXAMPLE_1.setHost("mail.example.com");
-    }
 
+        EXAMPLE_2 = new MailServerPopBean();
+        EXAMPLE_2.setName("Example");
+        EXAMPLE_2.setHost("mail.example.com");
+        EXAMPLE_2.setPort("110");
+        EXAMPLE_2.setProtocol("pop3");
+    }
 }

--- a/src/main/java/de/aservo/atlassian/confapi/model/MailServerSmtpBean.java
+++ b/src/main/java/de/aservo/atlassian/confapi/model/MailServerSmtpBean.java
@@ -49,6 +49,7 @@ public class MailServerSmtpBean extends AbstractMailServerProtocolBean {
     // Example instances for documentation and tests
 
     public static final MailServerSmtpBean EXAMPLE_1;
+    public static final MailServerSmtpBean EXAMPLE_2;
 
     static {
         EXAMPLE_1 = new MailServerSmtpBean();
@@ -57,6 +58,19 @@ public class MailServerSmtpBean extends AbstractMailServerProtocolBean {
         EXAMPLE_1.setFrom("mail@example.com");
         EXAMPLE_1.setPrefix("[Example]");
         EXAMPLE_1.setHost("mail.example.com");
+
+        EXAMPLE_2 = new MailServerSmtpBean();
+        EXAMPLE_2.setName("Example");
+        EXAMPLE_2.setAdminContact(null);
+        EXAMPLE_2.setFrom("mail@example.com");
+        EXAMPLE_2.setPrefix("[Example]");
+        EXAMPLE_2.setHost("mail.example.com");
+        EXAMPLE_2.setDescription("test smtp server");
+        EXAMPLE_2.setPort("25");
+        EXAMPLE_2.setProtocol("smtp");
+        EXAMPLE_2.setTimeout(2000);
+        EXAMPLE_2.setUsername("admin");
+        EXAMPLE_2.setPassword("password");
     }
 
 }

--- a/src/test/java/it/de/aservo/atlassian/confapi/rest/AbstractMailServerPopResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/atlassian/confapi/rest/AbstractMailServerPopResourceFuncTest.java
@@ -1,0 +1,91 @@
+package it.de.aservo.atlassian.confapi.rest;
+
+import de.aservo.atlassian.confapi.constants.ConfAPI;
+import de.aservo.atlassian.confapi.model.MailServerPopBean;
+import org.apache.wink.client.ClientAuthenticationException;
+import org.apache.wink.client.ClientResponse;
+import org.apache.wink.client.Resource;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public abstract class AbstractMailServerPopResourceFuncTest {
+
+    @Test
+    public void testGetMailserverPop() {
+        Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_POP).build();
+
+        ClientResponse clientResponse = mailserverResource.get();
+        assertEquals(Response.Status.OK.getStatusCode(), clientResponse.getStatusCode());
+
+        MailServerPopBean mailServerPopBean = clientResponse.getEntity(MailServerPopBean.class);
+        assertNotNull(mailServerPopBean);
+    }
+
+    @Test
+    public void testSetMailserverPop() {
+        Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_POP).build();
+
+        ClientResponse clientResponse = mailserverResource.put(getExampleBean());
+        assertEquals(Response.Status.OK.getStatusCode(), clientResponse.getStatusCode());
+
+        MailServerPopBean mailServerPopBean = clientResponse.getEntity(MailServerPopBean.class);
+        assertMailserverBeanAgainstExample(mailServerPopBean);
+    }
+
+    @Test(expected = ClientAuthenticationException.class)
+    public void testGetMailserverPopUnauthenticated() {
+        Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_POP)
+                .username("wrong")
+                .password("password")
+                .build();
+        mailserverResource.get();
+    }
+
+    @Test(expected = ClientAuthenticationException.class)
+    public void testSetMailserverPopUnauthenticated() {
+        Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_POP)
+                .username("wrong")
+                .password("password")
+                .build();
+        mailserverResource.put(getExampleBean());
+    }
+
+    @Test
+    @Ignore("cannot be executed because there is no default user with restricted access rights")
+    public void testGetMailserverPopUnauthorized() {
+        Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_POP)
+                .username("user")
+                .password("user")
+                .build();
+        mailserverResource.get();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), mailserverResource.put(getExampleBean()).getStatusCode());
+    }
+
+    @Test
+    @Ignore("cannot be executed because there is no default user with restricted access rights")
+    public void testSetMailserverPopUnauthorized() {
+        Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_POP)
+                .username("user")
+                .password("user")
+                .build();
+        mailserverResource.put(getExampleBean());
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), mailserverResource.put(getExampleBean()).getStatusCode());
+    }
+
+    protected void assertMailserverBeanAgainstExample(MailServerPopBean bean) {
+        MailServerPopBean exampleBean = getExampleBean();
+        //although field 'password' in 'AbstractMailServerProtocolBean' is annotated with '@EqualsExclude' equals still yields false if
+        //not the same. Thus, we need to reset the example password manually
+        exampleBean.setPassword(null);
+        assertEquals(exampleBean, bean);
+    }
+
+    protected MailServerPopBean getExampleBean() {
+        return MailServerPopBean.EXAMPLE_2;
+    }
+}

--- a/src/test/java/it/de/aservo/atlassian/confapi/rest/AbstractMailServerSmtpResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/atlassian/confapi/rest/AbstractMailServerSmtpResourceFuncTest.java
@@ -1,0 +1,91 @@
+package it.de.aservo.atlassian.confapi.rest;
+
+import de.aservo.atlassian.confapi.constants.ConfAPI;
+import de.aservo.atlassian.confapi.model.MailServerSmtpBean;
+import org.apache.wink.client.ClientAuthenticationException;
+import org.apache.wink.client.ClientResponse;
+import org.apache.wink.client.Resource;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public abstract class AbstractMailServerSmtpResourceFuncTest {
+
+    @Test
+    public void testGetMailserverImap() {
+        Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_SMTP).build();
+
+        ClientResponse clientResponse = mailserverResource.get();
+        assertEquals(Response.Status.OK.getStatusCode(), clientResponse.getStatusCode());
+
+        MailServerSmtpBean mailServerSmtpBean = clientResponse.getEntity(MailServerSmtpBean.class);
+        assertNotNull(mailServerSmtpBean);
+    }
+
+    @Test
+    public void testSetMailserverImap() {
+        Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_SMTP).build();
+
+        ClientResponse clientResponse = mailserverResource.put(getExampleBean());
+        assertEquals(Response.Status.OK.getStatusCode(), clientResponse.getStatusCode());
+
+        MailServerSmtpBean mailServerSmtpBean = clientResponse.getEntity(MailServerSmtpBean.class);
+        assertMailserverBeanAgainstExample(mailServerSmtpBean);
+    }
+
+    @Test(expected = ClientAuthenticationException.class)
+    public void testGetMailserverImapUnauthenticated() {
+        Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_SMTP)
+                .username("wrong")
+                .password("password")
+                .build();
+        mailserverResource.get();
+    }
+
+    @Test(expected = ClientAuthenticationException.class)
+    public void testSetMailserverImapUnauthenticated() {
+        Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_SMTP)
+                .username("wrong")
+                .password("password")
+                .build();
+        mailserverResource.put(getExampleBean());
+    }
+
+    @Test
+    @Ignore("cannot be executed because there is no default user with restricted access rights")
+    public void testGetMailserverImapUnauthorized() {
+        Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_SMTP)
+                .username("user")
+                .password("user")
+                .build();
+        mailserverResource.get();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), mailserverResource.put(getExampleBean()).getStatusCode());
+    }
+
+    @Test
+    @Ignore("cannot be executed because there is no default user with restricted access rights")
+    public void testSetMailserverImapUnauthorized() {
+        Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_SMTP)
+                .username("user")
+                .password("user")
+                .build();
+        mailserverResource.put(getExampleBean());
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), mailserverResource.put(getExampleBean()).getStatusCode());
+    }
+
+    protected void assertMailserverBeanAgainstExample(MailServerSmtpBean bean) {
+        MailServerSmtpBean exampleBean = getExampleBean();
+        //although field 'password' in 'AbstractMailServerProtocolBean' is annotated with '@EqualsExclude' equals still yields false if
+        //not the same. Thus, we need to reset the example password manually
+        exampleBean.setPassword(null);
+        assertEquals(exampleBean, bean);
+    }
+
+    protected MailServerSmtpBean getExampleBean() {
+        return MailServerSmtpBean.EXAMPLE_2;
+    }
+}


### PR DESCRIPTION
This commit introduces abstract integration testing for the mail server
resources. Two abstract classes are introduced for both smtp and pop mail
servers. The plugin may instantiate either or both of them depending on its
capabilities.

Additional smtp and pop sample beans are provided covering all required field
for live settings update.