### PR TITLE
package renaming W/O atlassian

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>confapi-commons</artifactId>
-    <version>0.0.8-SNAPSHOT</version>
+    <version>0.0.9-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ConfAPI Commons</name>

--- a/src/test/java/it/de/aservo/confapi/commons/rest/AbstractLicenseResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/AbstractLicenseResourceFuncTest.java
@@ -1,4 +1,4 @@
-package it.de.aservo.atlassian.confapi.rest;
+package it.de.aservo.confapi.commons.rest;
 
 import de.aservo.confapi.commons.constants.ConfAPI;
 import de.aservo.confapi.commons.model.LicenseBean;

--- a/src/test/java/it/de/aservo/confapi/commons/rest/AbstractMailServerPopResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/AbstractMailServerPopResourceFuncTest.java
@@ -1,4 +1,4 @@
-package it.de.aservo.atlassian.confapi.rest;
+package it.de.aservo.confapi.commons.rest;
 
 import de.aservo.confapi.commons.constants.ConfAPI;
 import de.aservo.confapi.commons.model.MailServerPopBean;

--- a/src/test/java/it/de/aservo/confapi/commons/rest/AbstractMailServerSmtpResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/AbstractMailServerSmtpResourceFuncTest.java
@@ -1,4 +1,4 @@
-package it.de.aservo.atlassian.confapi.rest;
+package it.de.aservo.confapi.commons.rest;
 
 import de.aservo.confapi.commons.constants.ConfAPI;
 import de.aservo.confapi.commons.model.MailServerSmtpBean;

--- a/src/test/java/it/de/aservo/confapi/commons/rest/AbstractPingResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/AbstractPingResourceFuncTest.java
@@ -1,4 +1,4 @@
-package it.de.aservo.atlassian.confapi.rest;
+package it.de.aservo.confapi.commons.rest;
 
 import de.aservo.confapi.commons.constants.ConfAPI;
 import org.apache.wink.client.Resource;

--- a/src/test/java/it/de/aservo/confapi/commons/rest/AbstractSettingsResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/AbstractSettingsResourceFuncTest.java
@@ -1,4 +1,4 @@
-package it.de.aservo.atlassian.confapi.rest;
+package it.de.aservo.confapi.commons.rest;
 
 import de.aservo.confapi.commons.constants.ConfAPI;
 import de.aservo.confapi.commons.model.SettingsBean;

--- a/src/test/java/it/de/aservo/confapi/commons/rest/AbstractUserResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/AbstractUserResourceFuncTest.java
@@ -1,4 +1,4 @@
-package it.de.aservo.atlassian.confapi.rest;
+package it.de.aservo.confapi.commons.rest;
 
 import de.aservo.confapi.commons.constants.ConfAPI;
 import de.aservo.confapi.commons.model.UserBean;

--- a/src/test/java/it/de/aservo/confapi/commons/rest/ClientApplication.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/ClientApplication.java
@@ -1,4 +1,4 @@
-package it.de.aservo.atlassian.confapi.rest;
+package it.de.aservo.confapi.commons.rest;
 
 import javax.ws.rs.core.Application;
 import java.util.Collections;

--- a/src/test/java/it/de/aservo/confapi/commons/rest/ResourceBuilder.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/ResourceBuilder.java
@@ -1,4 +1,4 @@
-package it.de.aservo.atlassian.confapi.rest;
+package it.de.aservo.confapi.commons.rest;
 
 import org.apache.wink.client.ClientConfig;
 import org.apache.wink.client.Resource;


### PR DESCRIPTION
In accordance with the other packages in the commons lib the integration tests
package should also follow the new naming strategy.