### PR TITLE
improvement of users resource integration test

### DIFF
--- a/src/test/java/it/de/aservo/confapi/commons/rest/AbstractUserResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/AbstractUserResourceFuncTest.java
@@ -52,9 +52,6 @@ public abstract class AbstractUserResourceFuncTest {
 
         ClientResponse clientResponse = usersResource.put(exampleBean.getPassword());
         assertEquals(Response.Status.OK.getStatusCode(), clientResponse.getStatusCode());
-
-        UserBean userBean = clientResponse.getEntity(UserBean.class);
-        assertEquals(exampleBean, userBean);
     }
 
     @Test(expected = ClientAuthenticationException.class)


### PR DESCRIPTION
this commit removes the entity equals check after setting a new password. This is because
the password is excluded from the equals check anyway.