### PR TITLE
Enable ignored integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>confapi-commons</artifactId>
-    <version>0.0.9-SNAPSHOT</version>
+    <version>0.0.10-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ConfAPI Commons</name>

--- a/src/test/java/it/de/aservo/confapi/commons/rest/AbstractLicenseResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/AbstractLicenseResourceFuncTest.java
@@ -6,7 +6,6 @@ import de.aservo.confapi.commons.model.LicensesBean;
 import org.apache.wink.client.ClientAuthenticationException;
 import org.apache.wink.client.ClientResponse;
 import org.apache.wink.client.Resource;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -75,7 +74,6 @@ public abstract class AbstractLicenseResourceFuncTest {
     }
 
     @Test
-    @Ignore("cannot be executed because there is no default user with restricted access rights")
     public void testGetLicensesUnauthorized() {
         Resource licensesResource = ResourceBuilder.builder(ConfAPI.LICENSES)
                 .username("user")
@@ -85,7 +83,6 @@ public abstract class AbstractLicenseResourceFuncTest {
     }
 
     @Test
-    @Ignore("cannot be executed because there is no default user with restricted access rights")
     public void testSetLicensesUnauthorized() {
         Resource licensesResource = ResourceBuilder.builder(ConfAPI.LICENSES)
                 .username("user")

--- a/src/test/java/it/de/aservo/confapi/commons/rest/AbstractMailServerPopResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/AbstractMailServerPopResourceFuncTest.java
@@ -5,7 +5,6 @@ import de.aservo.confapi.commons.model.MailServerPopBean;
 import org.apache.wink.client.ClientAuthenticationException;
 import org.apache.wink.client.ClientResponse;
 import org.apache.wink.client.Resource;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -56,7 +55,6 @@ public abstract class AbstractMailServerPopResourceFuncTest {
     }
 
     @Test
-    @Ignore("cannot be executed because there is no default user with restricted access rights")
     public void testGetMailserverPopUnauthorized() {
         Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_POP)
                 .username("user")
@@ -67,7 +65,6 @@ public abstract class AbstractMailServerPopResourceFuncTest {
     }
 
     @Test
-    @Ignore("cannot be executed because there is no default user with restricted access rights")
     public void testSetMailserverPopUnauthorized() {
         Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_POP)
                 .username("user")

--- a/src/test/java/it/de/aservo/confapi/commons/rest/AbstractMailServerSmtpResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/AbstractMailServerSmtpResourceFuncTest.java
@@ -5,7 +5,6 @@ import de.aservo.confapi.commons.model.MailServerSmtpBean;
 import org.apache.wink.client.ClientAuthenticationException;
 import org.apache.wink.client.ClientResponse;
 import org.apache.wink.client.Resource;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -56,7 +55,6 @@ public abstract class AbstractMailServerSmtpResourceFuncTest {
     }
 
     @Test
-    @Ignore("cannot be executed because there is no default user with restricted access rights")
     public void testGetMailserverImapUnauthorized() {
         Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_SMTP)
                 .username("user")
@@ -67,7 +65,6 @@ public abstract class AbstractMailServerSmtpResourceFuncTest {
     }
 
     @Test
-    @Ignore("cannot be executed because there is no default user with restricted access rights")
     public void testSetMailserverImapUnauthorized() {
         Resource mailserverResource = ResourceBuilder.builder(ConfAPI.MAIL_SERVER + "/" + ConfAPI.MAIL_SERVER_SMTP)
                 .username("user")

--- a/src/test/java/it/de/aservo/confapi/commons/rest/AbstractSettingsResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/AbstractSettingsResourceFuncTest.java
@@ -5,7 +5,6 @@ import de.aservo.confapi.commons.model.SettingsBean;
 import org.apache.wink.client.ClientAuthenticationException;
 import org.apache.wink.client.ClientResponse;
 import org.apache.wink.client.Resource;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -52,7 +51,6 @@ public abstract class AbstractSettingsResourceFuncTest {
     }
 
     @Test
-    @Ignore("cannot be executed because there is no default user with restricted access rights")
     public void testGetSettingsUnauthorized() {
         Resource settingsResource = ResourceBuilder.builder(ConfAPI.SETTINGS)
                 .username("user")
@@ -62,7 +60,6 @@ public abstract class AbstractSettingsResourceFuncTest {
     }
 
     @Test
-    @Ignore("cannot be executed because there is no default user with restricted access rights")
     public void testSetSettingsUnauthorized() {
         Resource settingsResource = ResourceBuilder.builder(ConfAPI.SETTINGS)
                 .username("user")

--- a/src/test/java/it/de/aservo/confapi/commons/rest/AbstractUserResourceFuncTest.java
+++ b/src/test/java/it/de/aservo/confapi/commons/rest/AbstractUserResourceFuncTest.java
@@ -5,7 +5,6 @@ import de.aservo.confapi.commons.model.UserBean;
 import org.apache.wink.client.ClientAuthenticationException;
 import org.apache.wink.client.ClientResponse;
 import org.apache.wink.client.Resource;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.ws.rs.core.MediaType;
@@ -75,7 +74,6 @@ public abstract class AbstractUserResourceFuncTest {
     }
 
     @Test
-    @Ignore("cannot be executed because there is no default user with restricted access rights")
     public void testGetUserUnauthorized() {
         UserBean exampleBean = getExampleBean();
         Resource usersResource = ResourceBuilder.builder(ConfAPI.USERS + getUserNameQueryParam(exampleBean))
@@ -87,7 +85,6 @@ public abstract class AbstractUserResourceFuncTest {
     }
 
     @Test
-    @Ignore("cannot be executed because there is no default user with restricted access rights")
     public void testSetUserEmailAddressUnauthorized() {
         UserBean exampleBean = getExampleBean();
         Resource usersResource = ResourceBuilder.builder(ConfAPI.USERS + getUserNameQueryParam(exampleBean))


### PR DESCRIPTION
The missing user 'user' has been prepared using a created home ZIP - also called
generated test resources - in the Confluence plugin.