### PR TITLE
Introduce DirectoryGenericBean for 'unsupported' directory types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,13 +111,13 @@
             </dependency>
 
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${hibernate-validator.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator-annotation-processor</artifactId>
                 <version>${hibernate-validator.version}</version>
             </dependency>
@@ -270,13 +270,13 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator-annotation-processor</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/de/aservo/confapi/commons/constants/ConfAPI.java
+++ b/src/main/java/de/aservo/confapi/commons/constants/ConfAPI.java
@@ -10,9 +10,10 @@ public class ConfAPI {
     public static final String BACKUP_QUEUE                 = "queue";
     public static final String DIRECTORIES                  = "directories";
     public static final String DIRECTORY                    = "directory";
-    public static final String DIRECTORY_INTERNAL           = "directory-internal";
-    public static final String DIRECTORY_CROWD              = "directory-crowd";
-    public static final String DIRECTORY_LDAP               = "directory-ldap";
+    public static final String DIRECTORY_CROWD              = "crowd";
+    public static final String DIRECTORY_GENERIC            = "generic";
+    public static final String DIRECTORY_INTERNAL           = "internal";
+    public static final String DIRECTORY_LDAP               = "ldap";
     public static final String ERROR                        = "error";
     public static final String ERRORS                       = "errors";
     public static final String GADGET                       = "gadget";

--- a/src/main/java/de/aservo/confapi/commons/model/AbstractDirectoryBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/AbstractDirectoryBean.java
@@ -1,5 +1,6 @@
 package de.aservo.confapi.commons.model;
 
+import de.aservo.confapi.commons.constants.ConfAPI;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.codehaus.jackson.annotate.JsonSubTypes;
@@ -20,11 +21,13 @@ import javax.xml.bind.annotation.XmlRootElement;
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
-        property = "type")
+        property = "type"
+)
 @JsonSubTypes({
-        @Type(value = DirectoryInternalBean.class, name = "internal"),
-        @Type(value = DirectoryCrowdBean.class, name = "crowd"),
-        @Type(value = DirectoryLdapBean.class, name = "ldap")
+        @Type(value = DirectoryCrowdBean.class, name = ConfAPI.DIRECTORY_CROWD),
+        @Type(value = DirectoryGenericBean.class, name = ConfAPI.DIRECTORY_GENERIC),
+        @Type(value = DirectoryInternalBean.class, name = ConfAPI.DIRECTORY_INTERNAL),
+        @Type(value = DirectoryLdapBean.class, name = ConfAPI.DIRECTORY_LDAP),
 })
 public abstract class AbstractDirectoryBean {
 

--- a/src/main/java/de/aservo/confapi/commons/model/DirectoriesBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/DirectoriesBean.java
@@ -20,6 +20,11 @@ import java.util.Collection;
 public class DirectoriesBean {
 
     @XmlElement
-    @Schema(oneOf = { DirectoryInternalBean.class, DirectoryCrowdBean.class, DirectoryLdapBean.class })
+    @Schema(oneOf = {
+            DirectoryCrowdBean.class,
+            DirectoryGenericBean.class,
+            DirectoryInternalBean.class,
+            DirectoryLdapBean.class,
+    })
     private Collection<AbstractDirectoryBean> directories;
 }

--- a/src/main/java/de/aservo/confapi/commons/model/DirectoryCrowdBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/DirectoryCrowdBean.java
@@ -17,7 +17,7 @@ import java.net.URI;
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-@XmlRootElement(name = ConfAPI.DIRECTORY_CROWD)
+@XmlRootElement(name = ConfAPI.DIRECTORY + '-' + ConfAPI.DIRECTORY_CROWD)
 public class DirectoryCrowdBean extends AbstractDirectoryBean {
 
     @XmlElement

--- a/src/main/java/de/aservo/confapi/commons/model/DirectoryGenericBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/DirectoryGenericBean.java
@@ -1,0 +1,19 @@
+package de.aservo.confapi.commons.model;
+
+import de.aservo.confapi.commons.constants.ConfAPI;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Bean for all user directories that are not supported by the plugin(s) yet.
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@XmlRootElement(name = ConfAPI.DIRECTORY + '-' + ConfAPI.DIRECTORY_GENERIC)
+public class DirectoryGenericBean extends AbstractDirectoryBean {
+
+}

--- a/src/main/java/de/aservo/confapi/commons/model/DirectoryInternalBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/DirectoryInternalBean.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-@XmlRootElement(name = ConfAPI.DIRECTORY_INTERNAL)
+@XmlRootElement(name = ConfAPI.DIRECTORY + '-' + ConfAPI.DIRECTORY_INTERNAL)
 public class DirectoryInternalBean extends AbstractDirectoryBean {
 
     @XmlElement

--- a/src/main/java/de/aservo/confapi/commons/model/DirectoryLdapBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/DirectoryLdapBean.java
@@ -16,7 +16,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-@XmlRootElement(name = ConfAPI.DIRECTORY_LDAP)
+@XmlRootElement(name = ConfAPI.DIRECTORY + '-' + ConfAPI.DIRECTORY_LDAP)
 public class DirectoryLdapBean extends AbstractDirectoryBean {
 
     @XmlElement


### PR DESCRIPTION
Wie besprochen.

Ich hab auch die Directory Konstanten sortiert und angepasst, was zwar zu diesem weniger schönen Konstrukt führt

```
@XmlRootElement(name = ConfAPI.DIRECTORY + '-' + ConfAPI.DIRECTORY_CROWD)
```

Allerdings haben wir so etwas auch schon bei den Mail Servern und dafür können wir die Konstanten nochmal wiederverwenden, wodurch der Mehrwert steigt:

```
@JsonSubTypes({
        @Type(value = DirectoryCrowdBean.class, name = ConfAPI.DIRECTORY_CROWD),
        @Type(value = DirectoryGenericBean.class, name = ConfAPI.DIRECTORY_GENERIC),
        @Type(value = DirectoryInternalBean.class, name = ConfAPI.DIRECTORY_INTERNAL),
        @Type(value = DirectoryLdapBean.class, name = ConfAPI.DIRECTORY_LDAP),
})
```

Das "überflüssige" Komma am Ende ist kleiner syntaktischer Zucker, der dazu führt, dass bei Hinzufügungen nach der letzten Zeile eine Modifikation weniger in Git erzeugt wird, da kein Komma hinzugefügt werden muss.

Außerdem habe ich wegen der entsprechenden Warnung in Maven die Hibernate Dependencies angepasst (könnte man einen extra PR für machen, fällt für mich unter die Pfadfinderegel).