### PR TITLE
ApplicationLinks with ignorable authentication errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>confapi-commons</artifactId>
-    <version>0.0.14-SNAPSHOT</version>
+    <version>0.0.15-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ConfAPI Commons</name>

--- a/src/main/java/de/aservo/confapi/commons/rest/AbstractApplicationLinksResourceImpl.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/AbstractApplicationLinksResourceImpl.java
@@ -22,14 +22,22 @@ public abstract class AbstractApplicationLinksResourceImpl implements Applicatio
     }
 
     @Override
-    public Response setApplicationLinks(ApplicationLinksBean linksBean) {
-        final ApplicationLinksBean updatedLinksBean = applicationLinksService.setApplicationLinks(linksBean);
+    public Response setApplicationLinks(
+            final boolean ignoreSetupErrors,
+            ApplicationLinksBean linksBean) {
+        final ApplicationLinksBean updatedLinksBean = applicationLinksService.setApplicationLinks(
+                linksBean,
+                ignoreSetupErrors);
         return Response.ok(updatedLinksBean).build();
     }
 
     @Override
-    public Response addApplicationLink(ApplicationLinkBean linkBean) {
-        final ApplicationLinkBean addedApplicationLink = applicationLinksService.addApplicationLink(linkBean);
+    public Response addApplicationLink(
+            final boolean ignoreSetupErrors,
+            ApplicationLinkBean linkBean) {
+        final ApplicationLinkBean addedApplicationLink = applicationLinksService.addApplicationLink(
+                linkBean,
+                ignoreSetupErrors);
         return Response.ok(addedApplicationLink).build();
     }
 }

--- a/src/main/java/de/aservo/confapi/commons/rest/api/ApplicationLinksResource.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/api/ApplicationLinksResource.java
@@ -11,10 +11,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -46,6 +48,7 @@ public interface ApplicationLinksResource {
             }
     )
     Response setApplicationLinks(
+            @QueryParam("ignore-setup-errors") @DefaultValue("false") final boolean ignoreSetupErrors,
             @NotNull final ApplicationLinksBean linksBean);
 
     @POST
@@ -61,6 +64,7 @@ public interface ApplicationLinksResource {
             }
     )
     Response addApplicationLink(
+            @QueryParam("ignore-setup-errors") @DefaultValue("false") final boolean ignoreSetupErrors,
             @NotNull final ApplicationLinkBean linkBean);
 
 }

--- a/src/main/java/de/aservo/confapi/commons/service/api/ApplicationLinksService.java
+++ b/src/main/java/de/aservo/confapi/commons/service/api/ApplicationLinksService.java
@@ -19,17 +19,23 @@ public interface ApplicationLinksService {
      * Sets the application links
      *
      * @param applicationLinksBean the application links to set
+     * @param ignoreSetupErrors whether or not to ignore authentication or other setup errors when setting up the link
+     *                          which usually happens if the application to link has not setup the link counterpart yet
      * @return the application links
      */
     public ApplicationLinksBean setApplicationLinks(
-            @NotNull final ApplicationLinksBean applicationLinksBean);
+            @NotNull final ApplicationLinksBean applicationLinksBean,
+            boolean ignoreSetupErrors);
 
     /**
      * Adds a single application link
      *
      * @param applicationLinkBean the application link to set
+     * @param ignoreSetupErrors whether or not to ignore authentication or other setup errors when setting up the link
+     *                          which usually happens if the application to link has not setup the link counterpart yet
      * @return the added application link
      */
     public ApplicationLinkBean addApplicationLink(
-            @NotNull final ApplicationLinkBean applicationLinkBean);
+            @NotNull final ApplicationLinkBean applicationLinkBean,
+            boolean ignoreSetupErrors);
 }

--- a/src/test/java/de/aservo/confapi/commons/rest/AbstractApplicationLinksResourceTest.java
+++ b/src/test/java/de/aservo/confapi/commons/rest/AbstractApplicationLinksResourceTest.java
@@ -44,9 +44,9 @@ public class AbstractApplicationLinksResourceTest {
     public void testSetApplicationLinks() {
         final ApplicationLinksBean bean = ApplicationLinksBean.EXAMPLE_1;
 
-        doReturn(bean).when(applicationLinksService).setApplicationLinks(bean);
+        doReturn(bean).when(applicationLinksService).setApplicationLinks(bean, true);
 
-        final Response response = resource.setApplicationLinks(bean);
+        final Response response = resource.setApplicationLinks(true, bean);
         assertEquals(200, response.getStatus());
         final ApplicationLinksBean linksBean = (ApplicationLinksBean) response.getEntity();
 
@@ -57,9 +57,9 @@ public class AbstractApplicationLinksResourceTest {
     public void testAddApplicationLink() {
         final ApplicationLinkBean bean = ApplicationLinkBean.EXAMPLE_1;
 
-        doReturn(bean).when(applicationLinksService).addApplicationLink(bean);
+        doReturn(bean).when(applicationLinksService).addApplicationLink(bean, true);
 
-        final Response response = resource.addApplicationLink(bean);
+        final Response response = resource.addApplicationLink(true, bean);
         assertEquals(200, response.getStatus());
         final ApplicationLinkBean responseBean = (ApplicationLinkBean) response.getEntity();
 


### PR DESCRIPTION
This commit modifies the application link API in order to allow for ignoring authentication
errors while setting up the link. This usually happens if the application to link to has
not setup the link counterpart yet.