### PR TITLE
ApplicationLink Status field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>confapi-commons</artifactId>
-    <version>0.0.16-SNAPSHOT</version>
+    <version>0.0.17-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ConfAPI Commons</name>

--- a/src/main/java/de/aservo/confapi/commons/model/ApplicationLinkBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/ApplicationLinkBean.java
@@ -19,6 +19,12 @@ import java.util.UUID;
 @XmlRootElement(name = ConfAPI.APPLICATION_LINK)
 public class ApplicationLinkBean {
 
+    public enum ApplicationLinkStatus {
+        AVAILABLE,
+        UNAVAILABLE,
+        CONFIGURATION_ERROR
+    }
+
     @XmlElement
     private String serverId;
 
@@ -46,6 +52,9 @@ public class ApplicationLinkBean {
 
     @XmlElement
     private boolean primary;
+
+    @XmlElement
+    private ApplicationLinkStatus status;
 
     @XmlElement
     private String username;


### PR DESCRIPTION
For GET access of application-link resources it is useful to also retrieve the
status of the link, e.g. in order to determine whether setting up the link
actually worked or not.