### PR TITLE
Parent pom 0.0.11 + rename service classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>de.aservo</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>0.0.10</version>
+        <version>0.0.11</version>
     </parent>
 
     <artifactId>confapi-commons</artifactId>
-    <version>0.0.18-SNAPSHOT</version>
+    <version>0.0.19-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ConfAPI Commons</name>

--- a/src/main/java/de/aservo/confapi/commons/rest/AbstractDirectoriesResourceImpl.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/AbstractDirectoriesResourceImpl.java
@@ -3,7 +3,7 @@ package de.aservo.confapi.commons.rest;
 import de.aservo.confapi.commons.model.AbstractDirectoryBean;
 import de.aservo.confapi.commons.model.DirectoriesBean;
 import de.aservo.confapi.commons.rest.api.DirectoriesResource;
-import de.aservo.confapi.commons.service.api.DirectoryService;
+import de.aservo.confapi.commons.service.api.DirectoriesService;
 
 import javax.ws.rs.core.Response;
 
@@ -11,15 +11,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public abstract class AbstractDirectoriesResourceImpl implements DirectoriesResource {
 
-    private final DirectoryService directoryService;
+    private final DirectoriesService directoriesService;
 
-    public AbstractDirectoriesResourceImpl(DirectoryService directoryService) {
-        this.directoryService = checkNotNull(directoryService);
+    public AbstractDirectoriesResourceImpl(DirectoriesService directoriesService) {
+        this.directoriesService = checkNotNull(directoriesService);
     }
 
     @Override
     public Response getDirectories() {
-        final DirectoriesBean directoriesBean = directoryService.getDirectories();
+        final DirectoriesBean directoriesBean = directoriesService.getDirectories();
         return Response.ok(directoriesBean).build();
     }
 
@@ -28,7 +28,7 @@ public abstract class AbstractDirectoriesResourceImpl implements DirectoriesReso
             final boolean testConnection,
             final DirectoriesBean directories) {
 
-        DirectoriesBean directoriesBean = directoryService.setDirectories(directories, testConnection);
+        DirectoriesBean directoriesBean = directoriesService.setDirectories(directories, testConnection);
         return Response.ok(directoriesBean).build();
     }
 
@@ -37,7 +37,7 @@ public abstract class AbstractDirectoriesResourceImpl implements DirectoriesReso
             final boolean testConnection,
             final AbstractDirectoryBean directory) {
 
-        AbstractDirectoryBean addedDirectoryBean = directoryService.addDirectory(directory, testConnection);
+        AbstractDirectoryBean addedDirectoryBean = directoriesService.addDirectory(directory, testConnection);
         return Response.ok(addedDirectoryBean).build();
     }
 }

--- a/src/main/java/de/aservo/confapi/commons/rest/AbstractUsersResourceImpl.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/AbstractUsersResourceImpl.java
@@ -2,23 +2,23 @@ package de.aservo.confapi.commons.rest;
 
 import de.aservo.confapi.commons.model.UserBean;
 import de.aservo.confapi.commons.rest.api.UsersResource;
-import de.aservo.confapi.commons.service.api.UserService;
+import de.aservo.confapi.commons.service.api.UsersService;
 
 import javax.ws.rs.core.Response;
 
 public class AbstractUsersResourceImpl implements UsersResource {
 
-    private final UserService userService;
+    private final UsersService usersService;
 
-    public AbstractUsersResourceImpl(final UserService userService) {
-        this.userService = userService;
+    public AbstractUsersResourceImpl(final UsersService usersService) {
+        this.usersService = usersService;
     }
 
     @Override
     public Response getUser(
             final String userName) {
 
-        final UserBean userBean = userService.getUser(userName);
+        final UserBean userBean = usersService.getUser(userName);
         return Response.ok(userBean).build();
     }
 
@@ -27,7 +27,7 @@ public class AbstractUsersResourceImpl implements UsersResource {
             final String userName,
             final UserBean userBean) {
 
-        final UserBean updatedUserBean = userService.updateUser(userName, userBean);
+        final UserBean updatedUserBean = usersService.updateUser(userName, userBean);
         return Response.ok(updatedUserBean).build();
     }
 
@@ -36,7 +36,7 @@ public class AbstractUsersResourceImpl implements UsersResource {
             final String userName,
             final String password) {
 
-        final UserBean updatedUserBean = userService.updatePassword(userName, password);
+        final UserBean updatedUserBean = usersService.updatePassword(userName, password);
         return Response.ok(updatedUserBean).build();
     }
 

--- a/src/main/java/de/aservo/confapi/commons/service/api/DirectoriesService.java
+++ b/src/main/java/de/aservo/confapi/commons/service/api/DirectoriesService.java
@@ -8,7 +8,7 @@ import javax.validation.constraints.NotNull;
 /**
  * The User directory service interface.
  */
-public interface DirectoryService {
+public interface DirectoriesService {
 
     /**
      * Gets directories.

--- a/src/main/java/de/aservo/confapi/commons/service/api/UsersService.java
+++ b/src/main/java/de/aservo/confapi/commons/service/api/UsersService.java
@@ -4,7 +4,7 @@ import de.aservo.confapi.commons.model.UserBean;
 
 import javax.validation.constraints.NotNull;
 
-public interface UserService {
+public interface UsersService {
 
     /**
      * Get the user.

--- a/src/test/java/de/aservo/confapi/commons/rest/AbstractDirectoriesResourceTest.java
+++ b/src/test/java/de/aservo/confapi/commons/rest/AbstractDirectoriesResourceTest.java
@@ -3,7 +3,7 @@ package de.aservo.confapi.commons.rest;
 import de.aservo.confapi.commons.model.AbstractDirectoryBean;
 import de.aservo.confapi.commons.model.DirectoriesBean;
 import de.aservo.confapi.commons.model.DirectoryCrowdBean;
-import de.aservo.confapi.commons.service.api.DirectoryService;
+import de.aservo.confapi.commons.service.api.DirectoriesService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,13 +21,13 @@ import static org.mockito.Mockito.doReturn;
 public class AbstractDirectoriesResourceTest {
 
     @Mock
-    private DirectoryService directoryService;
+    private DirectoriesService directoriesService;
 
     private TestDirectoriesResourceImpl resource;
 
     @Before
     public void setup() {
-        resource = new TestDirectoriesResourceImpl(directoryService);
+        resource = new TestDirectoriesResourceImpl(directoriesService);
     }
 
     @Test
@@ -35,7 +35,7 @@ public class AbstractDirectoriesResourceTest {
         DirectoryCrowdBean initialDirectoryBean = DirectoryCrowdBean.EXAMPLE_1;
         DirectoriesBean directoriesBean = new DirectoriesBean(Collections.singleton(initialDirectoryBean));
 
-        doReturn(directoriesBean).when(directoryService).getDirectories();
+        doReturn(directoriesBean).when(directoriesService).getDirectories();
 
         final Response response = resource.getDirectories();
         assertEquals(200, response.getStatus());
@@ -50,7 +50,7 @@ public class AbstractDirectoriesResourceTest {
         DirectoryCrowdBean directoryBean2 = DirectoryCrowdBean.EXAMPLE_3;
         DirectoriesBean directoriesBean = new DirectoriesBean(Arrays.asList(directoryBean1, directoryBean2));
 
-        doReturn(directoriesBean).when(directoryService).setDirectories(directoriesBean, false);
+        doReturn(directoriesBean).when(directoriesService).setDirectories(directoriesBean, false);
 
         final Response response = resource.setDirectories(Boolean.FALSE, directoriesBean);
         assertEquals(200, response.getStatus());
@@ -63,7 +63,7 @@ public class AbstractDirectoriesResourceTest {
     public void testAddDirectory() {
         DirectoryCrowdBean bean = DirectoryCrowdBean.EXAMPLE_1;
 
-        doReturn(bean).when(directoryService).addDirectory(bean, false);
+        doReturn(bean).when(directoriesService).addDirectory(bean, false);
 
         final Response response = resource.addDirectory(Boolean.FALSE, bean);
         assertEquals(200, response.getStatus());

--- a/src/test/java/de/aservo/confapi/commons/rest/AbstractUsersResourceTest.java
+++ b/src/test/java/de/aservo/confapi/commons/rest/AbstractUsersResourceTest.java
@@ -1,7 +1,7 @@
 package de.aservo.confapi.commons.rest;
 
 import de.aservo.confapi.commons.model.UserBean;
-import de.aservo.confapi.commons.service.api.UserService;
+import de.aservo.confapi.commons.service.api.UsersService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,20 +17,20 @@ import static org.mockito.Mockito.doReturn;
 public class AbstractUsersResourceTest {
 
     @Mock
-    private UserService userService;
+    private UsersService usersService;
 
     private TestUsersResourceImpl resource;
 
     @Before
     public void setup() {
-        resource = new TestUsersResourceImpl(userService);
+        resource = new TestUsersResourceImpl(usersService);
     }
 
     @Test
     public void testGetUser() {
         final UserBean bean = UserBean.EXAMPLE_1;
 
-        doReturn(bean).when(userService).getUser(bean.getUserName());
+        doReturn(bean).when(usersService).getUser(bean.getUserName());
 
         final Response response = resource.getUser(bean.getUserName());
         assertEquals(200, response.getStatus());
@@ -43,7 +43,7 @@ public class AbstractUsersResourceTest {
     public void testUpdateUser() {
         final UserBean bean = UserBean.EXAMPLE_1;
 
-        doReturn(bean).when(userService).updateUser(bean.getUserName(), bean);
+        doReturn(bean).when(usersService).updateUser(bean.getUserName(), bean);
 
         final Response response = resource.setUser(bean.getUserName(), bean);
         assertEquals(200, response.getStatus());
@@ -56,7 +56,7 @@ public class AbstractUsersResourceTest {
     public void testUpdateUserPassword() {
         final UserBean bean = UserBean.EXAMPLE_1;
 
-        doReturn(bean).when(userService).updatePassword(bean.getUserName(), bean.getPassword());
+        doReturn(bean).when(usersService).updatePassword(bean.getUserName(), bean.getPassword());
 
         final Response response = resource.setUserPassword(bean.getUserName(), bean.getPassword());
         assertEquals(200, response.getStatus());

--- a/src/test/java/de/aservo/confapi/commons/rest/TestDirectoriesResourceImpl.java
+++ b/src/test/java/de/aservo/confapi/commons/rest/TestDirectoriesResourceImpl.java
@@ -1,11 +1,11 @@
 package de.aservo.confapi.commons.rest;
 
-import de.aservo.confapi.commons.service.api.DirectoryService;
+import de.aservo.confapi.commons.service.api.DirectoriesService;
 
 public class TestDirectoriesResourceImpl extends AbstractDirectoriesResourceImpl {
 
-    public TestDirectoriesResourceImpl(DirectoryService directoryService) {
-        super(directoryService);
+    public TestDirectoriesResourceImpl(DirectoriesService directoriesService) {
+        super(directoriesService);
     }
 
 }

--- a/src/test/java/de/aservo/confapi/commons/rest/TestUsersResourceImpl.java
+++ b/src/test/java/de/aservo/confapi/commons/rest/TestUsersResourceImpl.java
@@ -1,11 +1,11 @@
 package de.aservo.confapi.commons.rest;
 
-import de.aservo.confapi.commons.service.api.UserService;
+import de.aservo.confapi.commons.service.api.UsersService;
 
 public class TestUsersResourceImpl extends AbstractUsersResourceImpl {
 
-    public TestUsersResourceImpl(UserService userService) {
-        super(userService);
+    public TestUsersResourceImpl(UsersService usersService) {
+        super(usersService);
     }
 
 }


### PR DESCRIPTION
Wir haben in den Services, in denen man mehrere Entitäten verarbeiten kann, bisher immer den Plural verwendet.

Übersehen haben wir das scheinbar beim DirectoryService und beim UserService, die ich hiermit angepasst habe.