### PR TITLE
Bean Validation Extension

### DIFF
--- a/src/main/java/de/aservo/confapi/commons/util/BeanValidationUtil.java
+++ b/src/main/java/de/aservo/confapi/commons/util/BeanValidationUtil.java
@@ -22,7 +22,15 @@ public class BeanValidationUtil {
     public static void validate(Object bean) {
         ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
         Validator validator = validatorFactory.getValidator();
-        Set<ConstraintViolation<Object>> violations = validator.validate(bean);
+        processValidationResult(validator.validate(bean));
+    }
+
+    /**
+     * Processes validation violations by throwing a ValidationException including the violation texts
+     *
+     * @param violations validation violations
+     */
+    public static void processValidationResult(Set<ConstraintViolation<Object>> violations) {
         if (!violations.isEmpty()) {
             List<String> collect = violations.stream().map(v -> v.getPropertyPath() + ": " + v.getMessage()).collect(Collectors.toList());
             throw new ValidationException(String.join("\n", collect));

--- a/src/test/java/de/aservo/confapi/commons/util/BeanValidationUtilTest.java
+++ b/src/test/java/de/aservo/confapi/commons/util/BeanValidationUtilTest.java
@@ -1,0 +1,26 @@
+package de.aservo.confapi.commons.util;
+
+import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ValidationException;
+import java.util.HashSet;
+import java.util.Set;
+
+public class BeanValidationUtilTest {
+
+    @Test
+    public void testThrowNoValidationException() {
+        Set<ConstraintViolation<Object>> violations = new HashSet<>();
+        BeanValidationUtil.processValidationResult(violations);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testThrowValidationException() {
+        Set<ConstraintViolation<Object>> violations = new HashSet<>();
+        violations.add(ConstraintViolationImpl.forBeanValidation("", null, null, "",
+                null, null, null, null, null, null, null));
+        BeanValidationUtil.processValidationResult(violations);
+    }
+}


### PR DESCRIPTION
Upon usage of the method `BeanValidationUtil.validate` in Bitbucket it was recognized that the required
javax.el dependencies cannot be provided as maven dependencies for runtime. However, a bitbucket internal
validator must be injected. This commit extracts the validator validation set processing for other
plugins to use when the default validator of the commons lib cannot be used.