### PR TITLE
Improve WebApplicationException mapping

### DIFF
--- a/src/main/java/de/aservo/confapi/commons/exception/mapper/WebApplicationExceptionMapper.java
+++ b/src/main/java/de/aservo/confapi/commons/exception/mapper/WebApplicationExceptionMapper.java
@@ -12,7 +12,8 @@ public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplica
 
     public Response toResponse(WebApplicationException e) {
         final ErrorCollection errorCollection = new ErrorCollection();
-        errorCollection.addErrorMessage(e.getMessage());
+        // there is no way around the cause in the WebApplicationException so that messages always start with the exception name
+        errorCollection.addErrorMessage(e.getMessage().replaceFirst("([^:]*: )", ""));
         return Response.status(e.getResponse().getStatus()).entity(errorCollection).build();
     }
 

--- a/src/test/java/de/aservo/confapi/commons/exception/mapper/WebApplicationExceptionMapperTest.java
+++ b/src/test/java/de/aservo/confapi/commons/exception/mapper/WebApplicationExceptionMapperTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertEquals;
 
 public class WebApplicationExceptionMapperTest {
 
-    private static final String MESSAGE = "Message";
+    private static final String MESSAGE = "Space with key 'KEY' does not exist";
 
     @Test
     public void testResponse() {
@@ -25,6 +25,10 @@ public class WebApplicationExceptionMapperTest {
 
         assertEquals("The response error collection size is wrong",
                 1, errorCollection.getErrorMessages().size());
+
+        final String errorMessage = errorCollection.getErrorMessages().iterator().next();
+
+        assertEquals(MESSAGE, errorMessage);
     }
 
 }


### PR DESCRIPTION
As the WebApplicationException needs to be instantiated by a Throwable and there
is no way to instantiate it with a String message only, the call `getMessage()`
always returns the `cause.toString` which always contains the exception class
name as a prefix for the actual message.

With this change, this exception class name is always removed from the exception
message again so that ErrorCollections don't contain any technical details
anymore.
