### PR TITLE
App link id from type long to UUID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>confapi-commons</artifactId>
-    <version>0.0.21-SNAPSHOT</version>
+    <version>0.0.23-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ConfAPI Commons</name>

--- a/src/main/java/de/aservo/confapi/commons/model/ApplicationLinkBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/ApplicationLinkBean.java
@@ -34,7 +34,7 @@ public class ApplicationLinkBean {
     }
 
     @XmlElement
-    private Long id;
+    private UUID id;
 
     @XmlElement
     private String serverId;

--- a/src/main/java/de/aservo/confapi/commons/rest/AbstractApplicationLinksResourceImpl.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/AbstractApplicationLinksResourceImpl.java
@@ -6,6 +6,7 @@ import de.aservo.confapi.commons.rest.api.ApplicationLinksResource;
 import de.aservo.confapi.commons.service.api.ApplicationLinksService;
 
 import javax.ws.rs.core.Response;
+import java.util.UUID;
 
 public abstract class AbstractApplicationLinksResourceImpl implements ApplicationLinksResource {
 
@@ -33,7 +34,7 @@ public abstract class AbstractApplicationLinksResourceImpl implements Applicatio
 
     @Override
     public Response setApplicationLink(
-            final long id,
+            final UUID id,
             final boolean ignoreSetupErrors,
             ApplicationLinkBean linkBean) {
         final ApplicationLinkBean updatedLinkBean = applicationLinksService.setApplicationLink(
@@ -62,7 +63,7 @@ public abstract class AbstractApplicationLinksResourceImpl implements Applicatio
 
     @Override
     public Response deleteApplicationLink(
-            final long id) {
+            final UUID id) {
         applicationLinksService.deleteApplicationLink(id);
         return Response.ok().build();
     }

--- a/src/main/java/de/aservo/confapi/commons/rest/api/ApplicationLinksResource.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/api/ApplicationLinksResource.java
@@ -22,6 +22,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.UUID;
 
 public interface ApplicationLinksResource {
 
@@ -68,7 +69,7 @@ public interface ApplicationLinksResource {
             }
     )
     Response setApplicationLink(
-            @PathParam("id") final long id,
+            @PathParam("id") @NotNull final UUID id,
             @QueryParam("ignore-setup-errors") @DefaultValue("false") final boolean ignoreSetupErrors,
             @NotNull final ApplicationLinkBean linksBean);
 
@@ -111,6 +112,6 @@ public interface ApplicationLinksResource {
             }
     )
     Response deleteApplicationLink(
-            @PathParam("id") final long id);
+            @PathParam("id") @NotNull final UUID id);
 
 }

--- a/src/main/java/de/aservo/confapi/commons/service/api/ApplicationLinksService.java
+++ b/src/main/java/de/aservo/confapi/commons/service/api/ApplicationLinksService.java
@@ -4,6 +4,7 @@ import de.aservo.confapi.commons.model.ApplicationLinkBean;
 import de.aservo.confapi.commons.model.ApplicationLinksBean;
 
 import javax.validation.constraints.NotNull;
+import java.util.UUID;
 
 public interface ApplicationLinksService {
 
@@ -37,7 +38,7 @@ public interface ApplicationLinksService {
      * @return the updated application link
      */
     public ApplicationLinkBean setApplicationLink(
-            final long id,
+            @NotNull final UUID id,
             @NotNull final ApplicationLinkBean applicationLinkBean,
             boolean ignoreSetupErrors);
 
@@ -66,5 +67,5 @@ public interface ApplicationLinksService {
      * @param id the application link id to delete
      */
     public void deleteApplicationLink(
-            final long id);
+            @NotNull final UUID id);
 }

--- a/src/test/java/de/aservo/confapi/commons/rest/AbstractApplicationLinksResourceTest.java
+++ b/src/test/java/de/aservo/confapi/commons/rest/AbstractApplicationLinksResourceTest.java
@@ -11,6 +11,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.ws.rs.core.Response;
 
+import java.util.UUID;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
@@ -57,10 +59,11 @@ public class AbstractApplicationLinksResourceTest {
     @Test
     public void testSetApplicationLink() {
         final ApplicationLinkBean bean = ApplicationLinkBean.EXAMPLE_1;
+        UUID id = UUID.randomUUID();
 
-        doReturn(bean).when(applicationLinksService).setApplicationLink(1L, bean, true);
+        doReturn(bean).when(applicationLinksService).setApplicationLink(id, bean, true);
 
-        final Response response = resource.setApplicationLink(1L, true, bean);
+        final Response response = resource.setApplicationLink(id, true, bean);
         assertEquals(200, response.getStatus());
         final ApplicationLinkBean linkBean = (ApplicationLinkBean) response.getEntity();
 
@@ -88,7 +91,7 @@ public class AbstractApplicationLinksResourceTest {
 
     @Test
     public void testDeleteApplicationLink() {
-        resource.deleteApplicationLink(1L);
+        resource.deleteApplicationLink(UUID.randomUUID());
         assertTrue("Delete Successful", true);
     }
 }


### PR DESCRIPTION
Switched app link id from type long to UUID in order to match Atlassians type scheme.