### PR TITLE
License service delete methods removed

### DIFF
--- a/src/main/java/de/aservo/confapi/commons/service/api/LicensesService.java
+++ b/src/main/java/de/aservo/confapi/commons/service/api/LicensesService.java
@@ -17,12 +17,12 @@ public interface LicensesService {
     /**
      * Gets a single liocense.
      *
-     * @param id the license product code to query
+     * @param product the license product code to query
      *
      * @return the gadget
      */
     LicenseBean getLicense(
-            @NotNull final String id);
+            @NotNull final String product);
 
     /**
      * Set or updates a list of licenses
@@ -41,7 +41,7 @@ public interface LicensesService {
      * @return the licenses
      */
     LicenseBean setLicense(
-            final String product,
+            @NotNull final String product,
             @NotNull final LicenseBean licenseBean);
 
     /**
@@ -52,20 +52,4 @@ public interface LicensesService {
      */
     LicenseBean addLicense(
             @NotNull final LicenseBean licenseBean);
-
-    /**
-     * Deletes all application links
-     *
-     * @param force must be set to 'true' in order to delete all entries
-     */
-    public void deleteLicenses(
-            boolean force);
-
-    /**
-     * Deletes a single license
-     *
-     * @param id the product key for which to delete the license
-     */
-    public void deleteLicense(
-            final long id);
 }


### PR DESCRIPTION
This commit removes the obsolete delete method of the license service. A few namings
were adjusted as well.