### PR TITLE
Map JSON mapping exceptions to bad request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,12 @@
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
-            <version>${jackson-jaxrs.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-jaxrs</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -302,12 +307,6 @@
         <dependency>
             <groupId>org.apache.wink</groupId>
             <artifactId>wink-client</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-jaxrs</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/de/aservo/confapi/commons/exception/mapper/JsonMappingExceptionMapper.java
+++ b/src/main/java/de/aservo/confapi/commons/exception/mapper/JsonMappingExceptionMapper.java
@@ -1,0 +1,19 @@
+package de.aservo.confapi.commons.exception.mapper;
+
+import de.aservo.confapi.commons.model.ErrorCollection;
+import org.codehaus.jackson.map.JsonMappingException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingException> {
+
+    public Response toResponse(JsonMappingException e) {
+        final ErrorCollection errorCollection = new ErrorCollection();
+        errorCollection.addErrorMessage(e.getMessage());
+        return Response.status(Response.Status.BAD_REQUEST).entity(errorCollection).build();
+    }
+
+}

--- a/src/test/java/de/aservo/confapi/commons/exception/mapper/JsonMappingExceptionMapperTest.java
+++ b/src/test/java/de/aservo/confapi/commons/exception/mapper/JsonMappingExceptionMapperTest.java
@@ -1,0 +1,31 @@
+package de.aservo.confapi.commons.exception.mapper;
+
+import de.aservo.confapi.commons.model.ErrorCollection;
+import org.codehaus.jackson.map.JsonMappingException;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.junit.Assert.assertEquals;
+
+public class JsonMappingExceptionMapperTest {
+
+    private static final String MESSAGE = "Message";
+
+    @Test
+    public void testResponse() {
+        final JsonMappingExceptionMapper jsonMappingExceptionMapper = new JsonMappingExceptionMapper();
+        final JsonMappingException jsonMappingException = new JsonMappingException(MESSAGE);
+        final Response response = jsonMappingExceptionMapper.toResponse(jsonMappingException);
+
+        assertEquals("Json mapping exceptions should be mapped to bad request exceptions",
+                BAD_REQUEST.getStatusCode(), response.getStatus());
+
+        final ErrorCollection errorCollection = (ErrorCollection) response.getEntity();
+
+        assertEquals("The response error collection size is wrong",
+                1, errorCollection.getErrorMessages().size());
+    }
+
+}


### PR DESCRIPTION
JsonMappingException gibt's bspw. wenn man einen Wert in einem Enum Attribut setzt, der nicht existiert.

Neues Verhalten:

```
{
  "errorMessages": [
    "Can not construct instance of de.aservo.confapi.crowd.model.ApplicationBean$ApplicationType from String value 'BLAAA': value not one of declared Enum instance names\n at [Source: org.apache.catalina.connector.CoyoteInputStream@2c5d359a; line: 4, column: 16] (through reference chain: de.aservo.confapi.crowd.model.ApplicationBean[\"type\"])"
  ]
}
```