### PR TITLE
Harmonize beans and interfaces

### DIFF
--- a/doc/CODE_CONVENTIONS.adoc
+++ b/doc/CODE_CONVENTIONS.adoc
@@ -139,7 +139,10 @@ public interface EntitiesResource {
             tags = { ConfAPI.ENTITIES },
             summary = "Get the list of entities",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = EntitiesBean.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = EntitiesBean.class)),
+                            description = ""
+                    ),
                     @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
             }
     )
@@ -153,7 +156,10 @@ public interface EntitiesResource {
             summary = "Add a new entity",
             description = "A new entity can be added here if no other entity with the same name already exists",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = EntityBean.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = EntityBean.class)),
+                            description = ""
+                    ),
                     @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
             }
     )

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>confapi-commons</artifactId>
-    <version>0.0.24-SNAPSHOT</version>
+    <version>0.0.25-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ConfAPI Commons</name>

--- a/src/main/java/de/aservo/confapi/commons/model/AbstractMailServerProtocolBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/AbstractMailServerProtocolBean.java
@@ -28,7 +28,7 @@ public abstract class AbstractMailServerProtocolBean {
     private String protocol;
 
     @XmlElement
-    private long timeout = 10000L;
+    private Long timeout;
 
     @XmlElement
     private String username;
@@ -77,4 +77,16 @@ public abstract class AbstractMailServerProtocolBean {
         }
     }
 
+    /**
+     * Return set timeout or default timeout of 10000L if null.
+     *
+     * @return timeout
+     */
+    public Long getTimeout() {
+        if (timeout == null) {
+            return 10000L;
+        }
+
+        return timeout;
+    }
 }

--- a/src/main/java/de/aservo/confapi/commons/model/ApplicationLinkBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/ApplicationLinkBean.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @XmlRootElement(name = ConfAPI.APPLICATION_LINK)
 public class ApplicationLinkBean {
 
-    public enum ApplicationLinkTypes {
+    public enum ApplicationLinkType {
         BAMBOO,
         JIRA,
         BITBUCKET,
@@ -34,7 +34,7 @@ public class ApplicationLinkBean {
     }
 
     @XmlElement
-    private UUID id;
+    private UUID uuid;
 
     @XmlElement
     @NotNull
@@ -42,7 +42,7 @@ public class ApplicationLinkBean {
 
     @XmlElement
     @NotNull
-    private ApplicationLinkTypes type;
+    private ApplicationLinkType type;
 
     @XmlElement
     @NotNull
@@ -70,12 +70,12 @@ public class ApplicationLinkBean {
 
     static {
         EXAMPLE_1 = new ApplicationLinkBean();
-        EXAMPLE_1.setId(UUID.randomUUID());
+        EXAMPLE_1.setUuid(UUID.randomUUID());
         EXAMPLE_1.setName("Example");
         EXAMPLE_1.setDisplayUrl(URI.create("http://example.com"));
         EXAMPLE_1.setRpcUrl(URI.create("http://rpc.example.com"));
         EXAMPLE_1.setPrimary(true);
-        EXAMPLE_1.setType(ApplicationLinkTypes.JIRA);
+        EXAMPLE_1.setType(ApplicationLinkType.JIRA);
         EXAMPLE_1.setUsername("username");
         EXAMPLE_1.setPassword("p455w0rd");
     }

--- a/src/main/java/de/aservo/confapi/commons/model/DirectoriesBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/DirectoriesBean.java
@@ -20,11 +20,12 @@ import java.util.Collection;
 public class DirectoriesBean {
 
     @XmlElement
-    @Schema(oneOf = {
+    @Schema(anyOf = {
             DirectoryCrowdBean.class,
             DirectoryGenericBean.class,
             DirectoryInternalBean.class,
             DirectoryLdapBean.class,
     })
     private Collection<AbstractDirectoryBean> directories;
+
 }

--- a/src/main/java/de/aservo/confapi/commons/model/LicenseBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/LicenseBean.java
@@ -20,6 +20,9 @@ import java.util.Date;
 public class LicenseBean {
 
     @XmlElement
+    private Collection<String> products;
+
+    @XmlElement
     private String type;
 
     @XmlElement
@@ -36,9 +39,6 @@ public class LicenseBean {
 
     @XmlElement
     private String key;
-
-    @XmlElement
-    private Collection<String> products;
 
     // Example instances for documentation and tests
 

--- a/src/main/java/de/aservo/confapi/commons/model/MailServerSmtpBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/MailServerSmtpBean.java
@@ -72,7 +72,7 @@ public class MailServerSmtpBean extends AbstractMailServerProtocolBean {
         EXAMPLE_2.setDescription("test smtp server");
         EXAMPLE_2.setPort("25");
         EXAMPLE_2.setProtocol("smtp");
-        EXAMPLE_2.setTimeout(2000);
+        EXAMPLE_2.setTimeout(2000L);
         EXAMPLE_2.setUsername("admin");
         EXAMPLE_2.setPassword("password");
     }

--- a/src/main/java/de/aservo/confapi/commons/rest/AbstractApplicationLinksResourceImpl.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/AbstractApplicationLinksResourceImpl.java
@@ -12,7 +12,9 @@ public abstract class AbstractApplicationLinksResourceImpl implements Applicatio
 
     private final ApplicationLinksService applicationLinksService;
 
-    public AbstractApplicationLinksResourceImpl(final ApplicationLinksService applicationLinksService) {
+    public AbstractApplicationLinksResourceImpl(
+            final ApplicationLinksService applicationLinksService) {
+
         this.applicationLinksService = applicationLinksService;
     }
 
@@ -24,8 +26,9 @@ public abstract class AbstractApplicationLinksResourceImpl implements Applicatio
 
     @Override
     public Response getApplicationLink(
-            final UUID id) {
-        final ApplicationLinkBean linkBean = applicationLinksService.getApplicationLink(id);
+            final UUID uuid) {
+
+        final ApplicationLinkBean linkBean = applicationLinksService.getApplicationLink(uuid);
         return Response.ok(linkBean).build();
     }
 
@@ -33,45 +36,46 @@ public abstract class AbstractApplicationLinksResourceImpl implements Applicatio
     public Response setApplicationLinks(
             final boolean ignoreSetupErrors,
             ApplicationLinksBean linksBean) {
+
         final ApplicationLinksBean updatedLinksBean = applicationLinksService.setApplicationLinks(
-                linksBean,
-                ignoreSetupErrors);
+                linksBean, ignoreSetupErrors);
         return Response.ok(updatedLinksBean).build();
     }
 
     @Override
     public Response setApplicationLink(
-            final UUID id,
+            final UUID uuid,
             final boolean ignoreSetupErrors,
-            ApplicationLinkBean linkBean) {
+            final ApplicationLinkBean linkBean) {
+
         final ApplicationLinkBean updatedLinkBean = applicationLinksService.setApplicationLink(
-                id,
-                linkBean,
-                ignoreSetupErrors);
+                uuid, linkBean, ignoreSetupErrors);
         return Response.ok(updatedLinkBean).build();
     }
 
     @Override
     public Response addApplicationLink(
             final boolean ignoreSetupErrors,
-            ApplicationLinkBean linkBean) {
+            final ApplicationLinkBean linkBean) {
+
         final ApplicationLinkBean addedApplicationLink = applicationLinksService.addApplicationLink(
-                linkBean,
-                ignoreSetupErrors);
+                linkBean, ignoreSetupErrors);
         return Response.ok(addedApplicationLink).build();
     }
 
     @Override
     public Response deleteApplicationLinks(
             final boolean force) {
+
         applicationLinksService.deleteApplicationLinks(force);
         return Response.ok().build();
     }
 
     @Override
     public Response deleteApplicationLink(
-            final UUID id) {
-        applicationLinksService.deleteApplicationLink(id);
+            final UUID uuid) {
+
+        applicationLinksService.deleteApplicationLink(uuid);
         return Response.ok().build();
     }
 }

--- a/src/main/java/de/aservo/confapi/commons/rest/AbstractUsersResourceImpl.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/AbstractUsersResourceImpl.java
@@ -16,27 +16,27 @@ public class AbstractUsersResourceImpl implements UsersResource {
 
     @Override
     public Response getUser(
-            final String userName) {
+            final String username) {
 
-        final UserBean userBean = usersService.getUser(userName);
+        final UserBean userBean = usersService.getUser(username);
         return Response.ok(userBean).build();
     }
 
     @Override
     public Response setUser(
-            final String userName,
+            final String username,
             final UserBean userBean) {
 
-        final UserBean updatedUserBean = usersService.updateUser(userName, userBean);
+        final UserBean updatedUserBean = usersService.updateUser(username, userBean);
         return Response.ok(updatedUserBean).build();
     }
 
     @Override
     public Response setUserPassword(
-            final String userName,
+            final String username,
             final String password) {
 
-        final UserBean updatedUserBean = usersService.updatePassword(userName, password);
+        final UserBean updatedUserBean = usersService.updatePassword(username, password);
         return Response.ok(updatedUserBean).build();
     }
 

--- a/src/main/java/de/aservo/confapi/commons/rest/api/ApplicationLinksResource.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/api/ApplicationLinksResource.java
@@ -31,39 +31,56 @@ public interface ApplicationLinksResource {
     @Operation(
             tags = { ConfAPI.APPLICATION_LINKS },
             summary = "Get all application links",
-            description = "Upon successful request, returns a `ApplicationLinksBean` object containing all application links",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationLinksBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationLinksBean.class)),
+                            description = "Returns all application links."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response getApplicationLinks();
 
     @GET
-    @Path("{id}")
+    @Path("{uuid}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.APPLICATION_LINKS },
-            summary = "Gets a single application link",
-            description = "Upon successful request, returns a `ApplicationLinkBean` object containing the requested application link",
+            summary = "Get an application link",
+            description = "Upon successful request, ",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationLinkBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationLinkBean.class)),
+                            description = "Returns the requested application link."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response getApplicationLink(
-            @PathParam("id") @NotNull final UUID id);
+            @PathParam("uuid") @NotNull final UUID uuid);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.APPLICATION_LINKS },
-            summary = "Sets or updates a set of application links",
-            description = "Upon successful request, returns a `ApplicationLinksBean` object containing all application links",
+            summary = "Set or update a list of application links",
+            description = "NOTE: All existing application links with the same 'rpcUrl' attribute are updated.",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationLinksBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationLinksBean.class)),
+                            description = "Returns all application links."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response setApplicationLinks(
@@ -71,20 +88,25 @@ public interface ApplicationLinksResource {
             @NotNull final ApplicationLinksBean linksBean);
 
     @PUT
-    @Path("{id}")
+    @Path("{uuid}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.APPLICATION_LINKS },
-            summary = "Updates an application link",
-            description = "Upon successful request, returns the updated `ApplicationLinkBean` object containing the updated application link",
+            summary = "Update an application link",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationLinkBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationLinkBean.class)),
+                            description = "Returns the updated application link."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response setApplicationLink(
-            @PathParam("id") @NotNull final UUID id,
+            @PathParam("uuid") @NotNull final UUID uuid,
             @QueryParam("ignore-setup-errors") @DefaultValue("false") final boolean ignoreSetupErrors,
             @NotNull final ApplicationLinkBean linksBean);
 
@@ -93,11 +115,16 @@ public interface ApplicationLinksResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.APPLICATION_LINKS },
-            summary = "Add a single application link",
-            description = "Upon successful request, returns the added `ApplicationLinkBean` object",
+            summary = "Add an application link",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationLinkBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationLinkBean.class)),
+                            description = "Returns the added application link."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response addApplicationLink(
@@ -107,26 +134,39 @@ public interface ApplicationLinksResource {
     @DELETE
     @Operation(
             tags = { ConfAPI.APPLICATION_LINKS },
-            summary = "Deletes all application links. NOTE: The 'force' parameter must be set to 'true' in order to execute this request.",
+            summary = "Delete all application links",
+            description = "NOTE: The 'force' parameter must be set to 'true' in order to execute this request.",
             responses = {
-                    @ApiResponse(responseCode = "200"),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Returns an empty body."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response deleteApplicationLinks(
             @QueryParam("force") final boolean force);
 
     @DELETE
-    @Path("{id}")
+    @Path("{uuid}")
     @Operation(
             tags = { ConfAPI.APPLICATION_LINKS },
-            summary = "Deletes a single application link",
+            summary = "Delete an application link",
             responses = {
-                    @ApiResponse(responseCode = "200"),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Returns an empty body."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response deleteApplicationLink(
-            @PathParam("id") @NotNull final UUID id);
+            @PathParam("uuid") @NotNull final UUID uuid);
 
 }

--- a/src/main/java/de/aservo/confapi/commons/rest/api/DirectoriesResource.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/api/DirectoriesResource.java
@@ -29,10 +29,16 @@ public interface DirectoriesResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.DIRECTORIES },
-            summary = "Get the list of user directories",
+            summary = "Get all user directories",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = DirectoriesBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = DirectoriesBean.class)),
+                            description = "Returns all directories."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response getDirectories();
@@ -42,10 +48,16 @@ public interface DirectoriesResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.DIRECTORIES },
-            summary = "Gets a single user directories",
+            summary = "Get a user directory",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = AbstractDirectoryBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = AbstractDirectoryBean.class)),
+                            description = "Returns the requested directory."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response getDirectory(
@@ -56,11 +68,17 @@ public interface DirectoriesResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.DIRECTORIES },
-            summary = "Sets or updates a list of directories",
-            description = "Any existing configurations with the same 'name' property is updated.",
+            summary = "Set or update a list of user directories",
+            description = "NOTE: All existing directories with the same 'name' attribute are updated.",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = DirectoriesBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = DirectoriesBean.class)),
+                            description = "Returns all directories."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response setDirectories(
@@ -73,11 +91,16 @@ public interface DirectoriesResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.DIRECTORIES },
-            summary = "Updates a single directory",
-            description = "Any existing configuration with the same 'name' property is updated.",
+            summary = "Update a user directory",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = AbstractDirectoryBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = AbstractDirectoryBean.class)),
+                            description = "Returns the updated directory."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response setDirectory(
@@ -90,11 +113,16 @@ public interface DirectoriesResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.DIRECTORIES },
-            summary = "Adds a new directory",
-            description = "Adds a new user directory to the existing list of directories",
+            summary = "Add a user directory",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = AbstractDirectoryBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = AbstractDirectoryBean.class)),
+                            description = "Returns the added directory."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response addDirectory(
@@ -104,10 +132,17 @@ public interface DirectoriesResource {
     @DELETE
     @Operation(
             tags = { ConfAPI.DIRECTORIES },
-            summary = "Deletes all user directories. NOTE: The 'force' parameter must be set to 'true' in order to execute this request.",
+            summary = "Delete all user directories",
+            description = "NOTE: The 'force' parameter must be set to 'true' in order to execute this request.",
             responses = {
-                    @ApiResponse(responseCode = "200"),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Returns an empty body."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response deleteDirectories(
@@ -117,10 +152,16 @@ public interface DirectoriesResource {
     @Path("{id}")
     @Operation(
             tags = { ConfAPI.DIRECTORIES },
-            summary = "Deletes a single user directory",
+            summary = "Delete a user directory",
             responses = {
-                    @ApiResponse(responseCode = "200"),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Returns an empty body."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response deleteDirectory(

--- a/src/main/java/de/aservo/confapi/commons/rest/api/GadgetsResource.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/api/GadgetsResource.java
@@ -29,10 +29,15 @@ public interface GadgetsResource {
     @Operation(
             tags = { ConfAPI.GADGETS },
             summary = "Get all gadgets",
-            description = "Upon successful request, returns a `GadgetsBean` object containing gadgets details",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = GadgetsBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = GadgetsBean.class)),
+                            description = "Returns all gadgets."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response getGadgets();
@@ -42,11 +47,16 @@ public interface GadgetsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.GADGETS },
-            summary = "Gets a single gadget",
-            description = "Upon successful request, returns a `GadgetsBean` object containing gadgets details",
+            summary = "Get a gadget",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = GadgetBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = GadgetBean.class)),
+                            description = "Returns the requested gadget."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response getGadget(
@@ -57,11 +67,17 @@ public interface GadgetsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.GADGETS },
-            summary = "Sets or updates a new list of gadgets",
-            description = "Upon successful request, returns a `GadgetsBean` object containing gadgets details",
+            summary = "Set or update a list of gadgets",
+            description = "NOTE: This will only create gadgets that does not exist yet as there is no real 'update'.",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = GadgetsBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = GadgetsBean.class)),
+                            description = "Returns all gadgets."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response setGadgets(
@@ -73,11 +89,16 @@ public interface GadgetsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.GADGETS },
-            summary = "Updates a single gadget",
-            description = "Upon successful request, returns a `GadgetBean` object containing gadget details",
+            summary = "Update a gadget",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = GadgetBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = GadgetBean.class)),
+                            description = "Returns the updated gadget."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response setGadget(
@@ -89,11 +110,17 @@ public interface GadgetsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.GADGETS },
-            summary = "Adds a single gadget",
-            description = "Upon successful request, returns the added `GadgetBean` object containing gadget details",
+            summary = "Add a gadget",
+            description = "Upon successful request, returns a `GadgetBean` object of the created gadget.",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = GadgetBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = GadgetBean.class)),
+                            description = "Returns the added gadget."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response addGadget(
@@ -102,10 +129,17 @@ public interface GadgetsResource {
     @DELETE
     @Operation(
             tags = { ConfAPI.GADGETS },
-            summary = "Deletes all gadgets. NOTE: The 'force' parameter must be set to 'true' in order to execute this request.",
+            summary = "Delete all gadgets",
+            description = "NOTE: The 'force' parameter must be set to 'true' in order to execute this request.",
             responses = {
-                    @ApiResponse(responseCode = "200"),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Returns an empty body."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response deleteGadgets(
@@ -115,12 +149,19 @@ public interface GadgetsResource {
     @Path("{id}")
     @Operation(
             tags = { ConfAPI.GADGETS },
-            summary = "Deletes a single gadget",
+            summary = "Delete a gadget",
             responses = {
-                    @ApiResponse(responseCode = "200"),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Returns an empty body."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response deleteGadget(
             @PathParam("id") final long id);
+
 }

--- a/src/main/java/de/aservo/confapi/commons/rest/api/LicensesResource.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/api/LicensesResource.java
@@ -29,8 +29,14 @@ public interface LicensesResource {
             summary = "Get all licenses information",
             description = "Upon successful request, returns a `LicensesBean` object containing license details. Be aware that `products` collection of the `LicenseBean` contains the product display names, not the product key names",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LicensesBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = LicensesBean.class)),
+                            description = ""
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response getLicenses();
@@ -43,8 +49,14 @@ public interface LicensesResource {
             summary = "Gets licenses information for a single license",
             description = "Upon successful request, returns a `LicenseBean` object containing license details.",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LicenseBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = LicenseBean.class)),
+                            description = ""
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response getLicense(
@@ -58,8 +70,14 @@ public interface LicensesResource {
             summary = "Sets or Updates a set of licenses",
             description = "Existing license details are always cleared before setting the new licenses. Upon successful request, returns a `LicensesBean` object containing license details",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LicensesBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = LicensesBean.class)),
+                            description = ""
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response setLicenses(
@@ -72,14 +90,20 @@ public interface LicensesResource {
     @Operation(
             tags = { ConfAPI.LICENSES },
             summary = "Updates a single license",
-            description = "Existing license details are always cleared before setting the new licenses. Upon successful request, returns a `LicenseBean` object containing license details",
+            description = "NOTE: Existing license details are always cleared before setting the new licenses.",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LicenseBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = LicenseBean.class)),
+                            description = "Returns the updated license details"
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response setLicense(
-            @PathParam("id") @NotNull final String product,
+            @NotNull @PathParam("id") final String product,
             @NotNull final LicenseBean licenseBean);
 
     @POST
@@ -87,13 +111,19 @@ public interface LicensesResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.LICENSES },
-            summary = "Adds a single license",
-            description = "Upon successful request, returns the added `LicenseBean` object containing license details",
+            summary = "Add a license",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LicenseBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = LicenseBean.class)),
+                            description = "Returns the added license details"
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response addLicense(
             @NotNull final LicenseBean licenseBean);
+
 }

--- a/src/main/java/de/aservo/confapi/commons/rest/api/MailServerPopResource.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/api/MailServerPopResource.java
@@ -26,9 +26,18 @@ public interface MailServerPopResource {
             tags = { ConfAPI.MAIL_SERVER },
             summary = "Get the default POP mail server",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MailServerPopBean.class))),
-                    @ApiResponse(responseCode = "204", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = MailServerPopBean.class)),
+                            description = "Returns the default POP mail server's details."
+                    ),
+                    @ApiResponse(
+                            responseCode = "204", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns an error message explaining that no default POP mail server is configured."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response getMailServerPop();
@@ -41,8 +50,14 @@ public interface MailServerPopResource {
             tags = { ConfAPI.MAIL_SERVER },
             summary = "Set the default POP mail server",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MailServerPopBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = MailServerPopBean.class)),
+                            description = "Returns the default POP mail server's details."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response setMailServerPop(

--- a/src/main/java/de/aservo/confapi/commons/rest/api/MailServerSmtpResource.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/api/MailServerSmtpResource.java
@@ -26,9 +26,18 @@ public interface MailServerSmtpResource {
             tags = { ConfAPI.MAIL_SERVER },
             summary = "Get the default SMTP mail server",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MailServerSmtpBean.class))),
-                    @ApiResponse(responseCode = "204", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = MailServerSmtpBean.class)),
+                            description = "Returns the default SMTP mail server's details."
+                    ),
+                    @ApiResponse(
+                            responseCode = "204", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns an error message explaining that no default SMTP mail server is configured."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response getMailServerSmtp();
@@ -41,8 +50,14 @@ public interface MailServerSmtpResource {
             tags = { ConfAPI.MAIL_SERVER },
             summary = "Set the default SMTP mail server",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MailServerSmtpBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = MailServerSmtpBean.class)),
+                            description = "Returns the default SMTP mail server's details."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response setMailServerSmtp(

--- a/src/main/java/de/aservo/confapi/commons/rest/api/PingResource.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/api/PingResource.java
@@ -17,9 +17,12 @@ public interface PingResource {
     @Produces(MediaType.TEXT_PLAIN)
     @Operation(
             tags = { ConfAPI.PING },
-            summary = "Simple ping method for probing the REST api. Returns 'pong' upon success",
+            summary = "Ping method for probing the REST API.",
             responses = {
-                    @ApiResponse(responseCode = "200"),
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Returns '" + PONG + "'"
+                    ),
             }
     )
     Response getPing();

--- a/src/main/java/de/aservo/confapi/commons/rest/api/SettingsResource.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/api/SettingsResource.java
@@ -24,8 +24,14 @@ public interface SettingsResource {
             tags = { ConfAPI.SETTINGS },
             summary = "Get the application settings",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBean.class)),
+                            description = "Returns the application settings"
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response getSettings();
@@ -37,8 +43,14 @@ public interface SettingsResource {
             tags = { ConfAPI.SETTINGS },
             summary = "Set the application settings",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBean.class)),
+                            description = "Returns the application settings"
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response setSettings(

--- a/src/main/java/de/aservo/confapi/commons/rest/api/UsersResource.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/api/UsersResource.java
@@ -24,30 +24,40 @@ public interface UsersResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.USERS },
-            summary = "Retrieves user information",
-            description = "Upon successful request, returns a `UserBean` object containing user details",
+            summary = "Get a user",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = UserBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = UserBean.class)),
+                            description = "Returns the requested user details"
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response getUser(
-            @NotNull @QueryParam("userName") final String userName);
+            @NotNull @QueryParam("username") final String username);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.USERS },
-            summary = "Updates user details",
-            description = "Upon successful request, returns the updated `UserBean` object (user name cannot be updated)",
+            summary = "Update an user",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = UserBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = UserBean.class)),
+                            description = "Returns the updated user details"
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response setUser(
-            @NotNull @QueryParam("userName") final String userName,
+            @NotNull @QueryParam("username") final String username,
             @NotNull final UserBean userBean);
 
     @PUT
@@ -56,15 +66,20 @@ public interface UsersResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.USERS },
-            summary = "Updates the user password",
-            description = "Upon successful request, returns the updated `UserBean` object.",
+            summary = "Update a user password",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = UserBean.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class))),
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = UserBean.class)),
+                            description = "Returns the user details"
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
             }
     )
     Response setUserPassword(
-            @NotNull @QueryParam("userName") final String userName,
+            @NotNull @QueryParam("username") final String username,
             @NotNull final String password);
 
 }

--- a/src/main/java/de/aservo/confapi/commons/service/api/ApplicationLinksService.java
+++ b/src/main/java/de/aservo/confapi/commons/service/api/ApplicationLinksService.java
@@ -13,41 +13,40 @@ public interface ApplicationLinksService {
      *
      * @return the application links
      */
-    public ApplicationLinksBean getApplicationLinks();
+    ApplicationLinksBean getApplicationLinks();
 
     /**
      * Gets a single application link.
      *
-     * @param id the application link id query
-     *
+     * @param uuid the application link uuid query
      * @return the application link
      */
-    public ApplicationLinkBean getApplicationLink(
-            final UUID id);
+    ApplicationLinkBean getApplicationLink(
+            final UUID uuid);
 
     /**
      * Sets or updates the given application links
      *
      * @param applicationLinksBean the application links to set / update
-     * @param ignoreSetupErrors whether or not to ignore authentication or other setup errors when setting up the link
-     *                          which usually happens if the application to link has not setup the link counterpart yet
+     * @param ignoreSetupErrors    whether or not to ignore authentication or other setup errors when setting up the link
+     *                             which usually happens if the application to link has not setup the link counterpart yet
      * @return the updated application links
      */
-    public ApplicationLinksBean setApplicationLinks(
+    ApplicationLinksBean setApplicationLinks(
             @NotNull final ApplicationLinksBean applicationLinksBean,
             boolean ignoreSetupErrors);
 
     /**
      * Updates the given application link
      *
-     * @param id the application link id to update
+     * @param uuid                the application link uuid to update
      * @param applicationLinkBean the application link to set / update
-     * @param ignoreSetupErrors whether or not to ignore authentication or other setup errors when setting up the link
-     *                          which usually happens if the application to link has not setup the link counterpart yet
+     * @param ignoreSetupErrors   whether or not to ignore authentication or other setup errors when setting up the link
+     *                            which usually happens if the application to link has not setup the link counterpart yet
      * @return the updated application link
      */
-    public ApplicationLinkBean setApplicationLink(
-            @NotNull final UUID id,
+    ApplicationLinkBean setApplicationLink(
+            @NotNull final UUID uuid,
             @NotNull final ApplicationLinkBean applicationLinkBean,
             boolean ignoreSetupErrors);
 
@@ -55,26 +54,28 @@ public interface ApplicationLinksService {
      * Adds a single application link
      *
      * @param applicationLinkBean the application link to set
-     * @param ignoreSetupErrors whether or not to ignore authentication or other setup errors when setting up the link
-     *                          which usually happens if the application to link has not setup the link counterpart yet
+     * @param ignoreSetupErrors   whether or not to ignore authentication or other setup errors when setting up the link
+     *                            which usually happens if the application to link has not setup the link counterpart yet
      * @return the added application link
      */
-    public ApplicationLinkBean addApplicationLink(
+    ApplicationLinkBean addApplicationLink(
             @NotNull final ApplicationLinkBean applicationLinkBean,
             boolean ignoreSetupErrors);
+
     /**
      * Deletes all application links
      *
      * @param force must be set to 'true' in order to delete all entries
      */
-    public void deleteApplicationLinks(
+    void deleteApplicationLinks(
             boolean force);
 
     /**
      * Deletes a single application link
      *
-     * @param id the application link id to delete
+     * @param uuid the application link uuid to delete
      */
-    public void deleteApplicationLink(
-            @NotNull final UUID id);
+    void deleteApplicationLink(
+            @NotNull final UUID uuid);
+
 }

--- a/src/main/java/de/aservo/confapi/commons/service/api/DirectoriesService.java
+++ b/src/main/java/de/aservo/confapi/commons/service/api/DirectoriesService.java
@@ -21,7 +21,6 @@ public interface DirectoriesService {
      * Gets a single directory.
      *
      * @param id the directory id to query
-     *
      * @return the directory
      */
     AbstractDirectoryBean getDirectory(
@@ -67,7 +66,7 @@ public interface DirectoriesService {
      *
      * @param force must be set to 'true' in order to delete all entries
      */
-    public void deleteDirectories(
+    void deleteDirectories(
             boolean force);
 
     /**
@@ -75,6 +74,6 @@ public interface DirectoriesService {
      *
      * @param id the directory id to delete
      */
-    public void deleteDirectory(
+    void deleteDirectory(
             final long id);
 }

--- a/src/main/java/de/aservo/confapi/commons/service/api/GadgetsService.java
+++ b/src/main/java/de/aservo/confapi/commons/service/api/GadgetsService.java
@@ -12,13 +12,12 @@ public interface GadgetsService {
      *
      * @return the gadgets
      */
-    public GadgetsBean getGadgets();
+    GadgetsBean getGadgets();
 
     /**
      * Gets a single gadget.
      *
      * @param id the gadget id to query
-     *
      * @return the gadget
      */
     GadgetBean getGadget(
@@ -30,16 +29,17 @@ public interface GadgetsService {
      * @param gadgetsBean the gadgets bean
      * @return the updated gadgets
      */
-    public GadgetsBean setGadgets(
+    GadgetsBean setGadgets(
             @NotNull final GadgetsBean gadgetsBean);
 
     /**
      * Updates a single gadgets.
      *
+     * @param id         the gadget id to update
      * @param gadgetBean the gadgets bean
      * @return the updated gadgets
      */
-    public GadgetBean setGadget(
+    GadgetBean setGadget(
             final long id,
             @NotNull final GadgetBean gadgetBean);
 
@@ -49,7 +49,7 @@ public interface GadgetsService {
      * @param gadgetBean the gadget bean to add
      * @return the added gadget
      */
-    public GadgetBean addGadget(
+    GadgetBean addGadget(
             @NotNull final GadgetBean gadgetBean);
 
     /**
@@ -57,7 +57,7 @@ public interface GadgetsService {
      *
      * @param force must be set to 'true' in order to delete all entries
      */
-    public void deleteGadgets(
+    void deleteGadgets(
             boolean force);
 
     /**
@@ -65,7 +65,7 @@ public interface GadgetsService {
      *
      * @param id the gadget id to delete
      */
-    public void deleteGadget(
+    void deleteGadget(
             final long id);
 
 }

--- a/src/main/java/de/aservo/confapi/commons/service/api/LicensesService.java
+++ b/src/main/java/de/aservo/confapi/commons/service/api/LicensesService.java
@@ -18,7 +18,6 @@ public interface LicensesService {
      * Gets a single liocense.
      *
      * @param product the license product code to query
-     *
      * @return the gadget
      */
     LicenseBean getLicense(
@@ -52,4 +51,5 @@ public interface LicensesService {
      */
     LicenseBean addLicense(
             @NotNull final LicenseBean licenseBean);
+
 }

--- a/src/main/java/de/aservo/confapi/commons/service/api/MailServerService.java
+++ b/src/main/java/de/aservo/confapi/commons/service/api/MailServerService.java
@@ -12,7 +12,7 @@ public interface MailServerService {
      *
      * @return the smtp mailserver settings
      */
-    public MailServerSmtpBean getMailServerSmtp();
+    MailServerSmtpBean getMailServerSmtp();
 
     /**
      * Sets the smtp mailserver settings.
@@ -20,7 +20,7 @@ public interface MailServerService {
      * @param smtpBean the smtp mailserver settings to set
      * @return the smtp mailserver settings
      */
-    public MailServerSmtpBean setMailServerSmtp(
+    MailServerSmtpBean setMailServerSmtp(
             @NotNull final MailServerSmtpBean smtpBean);
 
     /**
@@ -28,7 +28,7 @@ public interface MailServerService {
      *
      * @return the pop mailserver settings
      */
-    public MailServerPopBean getMailServerPop();
+    MailServerPopBean getMailServerPop();
 
     /**
      * Sets the pop mailserver settings.
@@ -36,6 +36,6 @@ public interface MailServerService {
      * @param popBean the pop mailserver settings to set
      * @return the pop mailserver settings
      */
-    public MailServerPopBean setMailServerPop(
+    MailServerPopBean setMailServerPop(
             @NotNull final MailServerPopBean popBean);
 }

--- a/src/main/java/de/aservo/confapi/commons/service/api/SettingsService.java
+++ b/src/main/java/de/aservo/confapi/commons/service/api/SettingsService.java
@@ -11,7 +11,7 @@ public interface SettingsService {
      *
      * @return the settings
      */
-    public SettingsBean getSettings();
+    SettingsBean getSettings();
 
 
     /**
@@ -20,6 +20,6 @@ public interface SettingsService {
      * @param settingsBean the settings to set
      * @return the settings
      */
-    public SettingsBean setSettings(
+    SettingsBean setSettings(
             @NotNull final SettingsBean settingsBean);
 }

--- a/src/main/java/de/aservo/confapi/commons/service/api/UsersService.java
+++ b/src/main/java/de/aservo/confapi/commons/service/api/UsersService.java
@@ -9,32 +9,32 @@ public interface UsersService {
     /**
      * Get the user.
      *
-     * @param userName the user name
+     * @param username the user name
      * @return the user bean
      */
-    public UserBean getUser(
-            @NotNull final String userName);
+    UserBean getUser(
+            @NotNull final String username);
 
     /**
      * Update the user.
      *
-     * @param userName the user name
+     * @param username the user name
      * @param userBean the user bean
      * @return the updated user bean
      */
-    public UserBean updateUser(
-            @NotNull final String userName,
+    UserBean updateUser(
+            @NotNull final String username,
             @NotNull final UserBean userBean);
 
     /**
      * Update the user password.
      *
-     * @param userName the user name
+     * @param username the user name
      * @param password the password
      * @return the updated user bean
      */
-    public UserBean updatePassword(
-            @NotNull final String userName,
+    UserBean updatePassword(
+            @NotNull final String username,
             @NotNull final String password);
 
 }

--- a/src/test/java/de/aservo/confapi/commons/model/MailServerPopBeanTest.java
+++ b/src/test/java/de/aservo/confapi/commons/model/MailServerPopBeanTest.java
@@ -1,9 +1,26 @@
 package de.aservo.confapi.commons.model;
 
 import de.aservo.confapi.commons.junit.AbstractBeanTest;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 @RunWith(MockitoJUnitRunner.class)
 public class MailServerPopBeanTest extends AbstractBeanTest {
+
+    @Test
+    public void testTimeoutHasDefaultValue() {
+        final long timeout = 12345L;
+        final MailServerPopBean beanWithTimeoutSet = new MailServerPopBean();
+
+        beanWithTimeoutSet.setTimeout(timeout);
+        assertEquals(timeout, beanWithTimeoutSet.getTimeout().longValue());
+
+        final MailServerPopBean beanWithoutTimeoutSet = new MailServerPopBean();
+        assertNotNull(beanWithoutTimeoutSet.getTimeout());
+    }
+
 }

--- a/src/test/java/de/aservo/confapi/commons/model/MailServerSmtpBeanTest.java
+++ b/src/test/java/de/aservo/confapi/commons/model/MailServerSmtpBeanTest.java
@@ -1,9 +1,26 @@
 package de.aservo.confapi.commons.model;
 
 import de.aservo.confapi.commons.junit.AbstractBeanTest;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 @RunWith(MockitoJUnitRunner.class)
 public class MailServerSmtpBeanTest extends AbstractBeanTest {
+
+    @Test
+    public void testTimeoutHasDefaultValue() {
+        final long timeout = 12345L;
+        final MailServerSmtpBean beanWithTimeoutSet = new MailServerSmtpBean();
+
+        beanWithTimeoutSet.setTimeout(timeout);
+        assertEquals(timeout, beanWithTimeoutSet.getTimeout().longValue());
+
+        final MailServerSmtpBean beanWithoutTimeoutSet = new MailServerSmtpBean();
+        assertNotNull(beanWithoutTimeoutSet.getTimeout());
+    }
+
 }


### PR DESCRIPTION
Commit 1:

```
Harmonize remaining model attributes
    
List of changes:
    
- Make timeout a `Long` and move default value to getter
- Rename UUID `id` attribute to `uuid`
- Rename `ApplicationLinkTypes` enum to be singular
- Change wrong `oneOf` to `anyOf` schema for directories
- Move licenses `products` attribute up as they also serve as an identifier
```

Commit 2:

```
Update Swagger resource documentation
    
The wording has been harmonized. The summary always explains the method from a
user's perspective while the response descriptions explains from the endpoints
perspective.
    
Response descriptions have been moved from the general method description to the
actual response descriptions which allows removing redundances (always naming
the bean class again) and prevents Swagger validation errors.
```

Commit 3:

```
Clean up services, remove 'public's, reformat code, rename variables
```