### PR TITLE
fix to prevent the  "Conflicting setter definitions for property"

### DIFF
--- a/src/main/java/de/aservo/confapi/commons/model/AbstractMailServerProtocolBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/AbstractMailServerProtocolBean.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeExclude;
+import org.codehaus.jackson.annotate.JsonIgnore;
 
 import javax.xml.bind.annotation.XmlElement;
 
@@ -45,6 +46,7 @@ public abstract class AbstractMailServerProtocolBean {
      *
      * @param port the port
      */
+    @JsonIgnore     //prevent "Conflicting setter definitions for property \"port\", see https://stackoverflow.com/questions/6346018/deserializing-json-into-object-with-overloaded-methods-using-jackson
     public void setPort(
             final int port) {
 


### PR DESCRIPTION
fix to prevent the  "Conflicting setter definitions for property \"port\"
error when deserializing with jackson