### PR TITLE
com.fasterxml.jackson support added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>confapi-commons</artifactId>
-    <version>0.0.27-SNAPSHOT</version>
+    <version>0.0.28-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ConfAPI Commons</name>
@@ -56,6 +56,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
         <jackson-jaxrs.version>1.9.13-atlassian-5</jackson-jaxrs.version>
+        <jackson-jaxrs-json-provider.version>2.11.3</jackson-jaxrs-json-provider.version>
         <javax.el-api.version>2.2.4</javax.el-api.version>
         <javax.inject.version>1</javax.inject.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
@@ -157,6 +158,12 @@
                 <artifactId>jackson-core-asl</artifactId>
                 <version>${jackson-jaxrs.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <version>${jackson-jaxrs-json-provider.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -237,6 +244,12 @@
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-jaxrs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/de/aservo/confapi/commons/model/AbstractDirectoryBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/AbstractDirectoryBean.java
@@ -1,11 +1,11 @@
 package de.aservo.confapi.commons.model;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import de.aservo.confapi.commons.constants.ConfAPI;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.codehaus.jackson.annotate.JsonSubTypes;
-import org.codehaus.jackson.annotate.JsonSubTypes.Type;
-import org.codehaus.jackson.annotate.JsonTypeInfo;
 
 import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlElement;
@@ -20,7 +20,11 @@ import java.util.Date;
 @XmlRootElement
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
-        include = JsonTypeInfo.As.PROPERTY,
+        property = "type"
+)
+@org.codehaus.jackson.annotate.JsonTypeInfo(
+        use = org.codehaus.jackson.annotate.JsonTypeInfo.Id.NAME,
+        include = org.codehaus.jackson.annotate.JsonTypeInfo.As.PROPERTY,
         property = "type"
 )
 @JsonSubTypes({
@@ -28,6 +32,12 @@ import java.util.Date;
         @Type(value = DirectoryGenericBean.class, name = ConfAPI.DIRECTORY_GENERIC),
         @Type(value = DirectoryInternalBean.class, name = ConfAPI.DIRECTORY_INTERNAL),
         @Type(value = DirectoryLdapBean.class, name = ConfAPI.DIRECTORY_LDAP),
+})
+@org.codehaus.jackson.annotate.JsonSubTypes({
+        @org.codehaus.jackson.annotate.JsonSubTypes.Type(value = DirectoryCrowdBean.class, name = ConfAPI.DIRECTORY_CROWD),
+        @org.codehaus.jackson.annotate.JsonSubTypes.Type(value = DirectoryGenericBean.class, name = ConfAPI.DIRECTORY_GENERIC),
+        @org.codehaus.jackson.annotate.JsonSubTypes.Type(value = DirectoryInternalBean.class, name = ConfAPI.DIRECTORY_INTERNAL),
+        @org.codehaus.jackson.annotate.JsonSubTypes.Type(value = DirectoryLdapBean.class, name = ConfAPI.DIRECTORY_LDAP),
 })
 public abstract class AbstractDirectoryBean {
 


### PR DESCRIPTION
this commit adds com.fasterxml.jackson dependencies in order to allow up-to-date
jackson providers to consume model annotations as well. The deprecated
org.codehaus.jackson must still co-exist in order to allow Atlassian apps to consume
the beans as well (Atlassian still ships with these outdated versions)