### PR TITLE
Naming and Path fixes for branding API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>confapi-commons</artifactId>
-    <version>0.0.28-SNAPSHOT</version>
+    <version>0.0.29-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ConfAPI Commons</name>

--- a/src/main/java/de/aservo/confapi/commons/constants/ConfAPI.java
+++ b/src/main/java/de/aservo/confapi/commons/constants/ConfAPI.java
@@ -11,7 +11,7 @@ public class ConfAPI {
     public static final String BACKUP_EXPORT                = "export";
     public static final String BACKUP_IMPORT                = "import";
     public static final String BACKUP_QUEUE                 = "queue";
-    public static final String COLOUR_SCHEME                = "colour-scheme";
+    public static final String COLOR_SCHEME                 = "color-scheme";
     public static final String DIRECTORIES                  = "directories";
     public static final String DIRECTORY                    = "directory";
     public static final String DIRECTORY_CROWD              = "crowd";

--- a/src/main/java/de/aservo/confapi/commons/model/SettingsBrandingColorSchemeBean.java
+++ b/src/main/java/de/aservo/confapi/commons/model/SettingsBrandingColorSchemeBean.java
@@ -12,9 +12,9 @@ import static de.aservo.confapi.commons.constants.ConfAPI.*;
 
 @Data
 @NoArgsConstructor
-@XmlRootElement(name = SETTINGS + "-" + BRANDING + "-" + COLOUR_SCHEME)
+@XmlRootElement(name = SETTINGS + "-" + BRANDING + "-" + COLOR_SCHEME)
 @XmlAccessorType(XmlAccessType.FIELD)
-public class SettingsBrandingColourSchemeBean {
+public class SettingsBrandingColorSchemeBean {
 
     @XmlElement
     private String topBar;
@@ -66,12 +66,12 @@ public class SettingsBrandingColourSchemeBean {
 
     // Example instances for documentation and tests
 
-    public static final SettingsBrandingColourSchemeBean EXAMPLE_1;
+    public static final SettingsBrandingColorSchemeBean EXAMPLE_1;
 
     static {
         final String COLOR_WHITE = "#FFFFFF";
 
-        EXAMPLE_1 = new SettingsBrandingColourSchemeBean();
+        EXAMPLE_1 = new SettingsBrandingColorSchemeBean();
         EXAMPLE_1.setBordersAndDividers(COLOR_WHITE);
         EXAMPLE_1.setHeaderButtonBackground(COLOR_WHITE);
         EXAMPLE_1.setHeaderButtonText(COLOR_WHITE);

--- a/src/main/java/de/aservo/confapi/commons/rest/AbstractSettingsBrandingResourceImpl.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/AbstractSettingsBrandingResourceImpl.java
@@ -1,29 +1,29 @@
 package de.aservo.confapi.commons.rest;
 
-import de.aservo.confapi.commons.model.SettingsBrandingColourSchemeBean;
+import de.aservo.confapi.commons.model.SettingsBrandingColorSchemeBean;
 import de.aservo.confapi.commons.rest.api.SettingsBrandingResource;
-import de.aservo.confapi.commons.service.api.BrandingService;
+import de.aservo.confapi.commons.service.api.SettingsBrandingService;
 
 import javax.ws.rs.core.Response;
 import java.io.InputStream;
 
 public abstract class AbstractSettingsBrandingResourceImpl implements SettingsBrandingResource {
 
-    private final BrandingService brandingService;
+    private final SettingsBrandingService brandingService;
 
-    public AbstractSettingsBrandingResourceImpl(final BrandingService brandingService) {
+    public AbstractSettingsBrandingResourceImpl(final SettingsBrandingService brandingService) {
         this.brandingService = brandingService;
     }
 
     @Override
     public Response getColourScheme() {
-        final SettingsBrandingColourSchemeBean colourSchemeBean = brandingService.getColourScheme();
+        final SettingsBrandingColorSchemeBean colourSchemeBean = brandingService.getColourScheme();
         return Response.ok(colourSchemeBean).build();
     }
 
     @Override
-    public Response setColourScheme(SettingsBrandingColourSchemeBean bean) {
-        final SettingsBrandingColourSchemeBean colourSchemeBean = brandingService.setColourScheme(bean);
+    public Response setColourScheme(SettingsBrandingColorSchemeBean bean) {
+        final SettingsBrandingColorSchemeBean colourSchemeBean = brandingService.setColourScheme(bean);
         return Response.ok(colourSchemeBean).build();
     }
 

--- a/src/main/java/de/aservo/confapi/commons/rest/api/SettingsBrandingResource.java
+++ b/src/main/java/de/aservo/confapi/commons/rest/api/SettingsBrandingResource.java
@@ -1,7 +1,7 @@
 package de.aservo.confapi.commons.rest.api;
 
 import de.aservo.confapi.commons.constants.ConfAPI;
-import de.aservo.confapi.commons.model.SettingsBrandingColourSchemeBean;
+import de.aservo.confapi.commons.model.SettingsBrandingColorSchemeBean;
 import de.aservo.confapi.commons.model.ErrorCollection;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -12,6 +12,7 @@ import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -20,13 +21,14 @@ import java.io.InputStream;
 public interface SettingsBrandingResource {
 
     @GET
+    @Path(ConfAPI.COLOR_SCHEME)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { ConfAPI.SETTINGS },
             summary = "Get the colour scheme",
             responses = {
                     @ApiResponse(
-                            responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBrandingColourSchemeBean.class)),
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBrandingColorSchemeBean.class)),
                             description = "Returns the colour scheme"
                     ),
                     @ApiResponse(
@@ -38,6 +40,7 @@ public interface SettingsBrandingResource {
     Response getColourScheme();
 
     @PUT
+    @Path(ConfAPI.COLOR_SCHEME)
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
@@ -45,7 +48,7 @@ public interface SettingsBrandingResource {
             summary = "Set the colour scheme",
             responses = {
                     @ApiResponse(
-                            responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBrandingColourSchemeBean.class)),
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBrandingColorSchemeBean.class)),
                             description = "Returns the updated colour scheme"
                     ),
                     @ApiResponse(
@@ -55,9 +58,10 @@ public interface SettingsBrandingResource {
             }
     )
     Response setColourScheme(
-            @NotNull final SettingsBrandingColourSchemeBean bean);
+            @NotNull final SettingsBrandingColorSchemeBean bean);
 
     @GET
+    @Path(ConfAPI.LOGO)
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     @Operation(
             tags = { ConfAPI.SETTINGS },
@@ -76,6 +80,7 @@ public interface SettingsBrandingResource {
     Response getLogo();
 
     @PUT
+    @Path(ConfAPI.LOGO)
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
@@ -96,6 +101,7 @@ public interface SettingsBrandingResource {
             @NotNull final InputStream binaryInputStream);
 
     @GET
+    @Path(ConfAPI.FAVICON)
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     @Operation(
             tags = { ConfAPI.SETTINGS },
@@ -114,6 +120,7 @@ public interface SettingsBrandingResource {
     Response getFavicon();
 
     @PUT
+    @Path(ConfAPI.FAVICON)
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(

--- a/src/main/java/de/aservo/confapi/commons/service/api/SettingsBrandingService.java
+++ b/src/main/java/de/aservo/confapi/commons/service/api/SettingsBrandingService.java
@@ -1,18 +1,18 @@
 package de.aservo.confapi.commons.service.api;
 
-import de.aservo.confapi.commons.model.SettingsBrandingColourSchemeBean;
+import de.aservo.confapi.commons.model.SettingsBrandingColorSchemeBean;
 
 import javax.validation.constraints.NotNull;
 import java.io.InputStream;
 
-public interface BrandingService {
+public interface SettingsBrandingService {
 
     /**
      * Get the colour scheme.
      *
      * @return the colour scheme
      */
-    SettingsBrandingColourSchemeBean getColourScheme();
+    SettingsBrandingColorSchemeBean getColourScheme();
 
 
     /**
@@ -21,8 +21,8 @@ public interface BrandingService {
      * @param colourSchemeBean the colour scheme to set
      * @return the updated colour scheme
      */
-    SettingsBrandingColourSchemeBean setColourScheme(
-            @NotNull final SettingsBrandingColourSchemeBean colourSchemeBean);
+    SettingsBrandingColorSchemeBean setColourScheme(
+            @NotNull final SettingsBrandingColorSchemeBean colourSchemeBean);
 
     /**
      * Get the logo binary.

--- a/src/test/java/de/aservo/confapi/commons/model/SettingsBrandingColorSchemeBeanTest.java
+++ b/src/test/java/de/aservo/confapi/commons/model/SettingsBrandingColorSchemeBeanTest.java
@@ -5,5 +5,5 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SettingsBrandingColourSchemeBeanTest extends AbstractBeanTest {
+public class SettingsBrandingColorSchemeBeanTest extends AbstractBeanTest {
 }

--- a/src/test/java/de/aservo/confapi/commons/rest/AbstractSettingsBrandingResourceTest.java
+++ b/src/test/java/de/aservo/confapi/commons/rest/AbstractSettingsBrandingResourceTest.java
@@ -1,7 +1,7 @@
 package de.aservo.confapi.commons.rest;
 
-import de.aservo.confapi.commons.model.SettingsBrandingColourSchemeBean;
-import de.aservo.confapi.commons.service.api.BrandingService;
+import de.aservo.confapi.commons.model.SettingsBrandingColorSchemeBean;
+import de.aservo.confapi.commons.service.api.SettingsBrandingService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.doReturn;
 public class AbstractSettingsBrandingResourceTest {
 
     @Mock
-    private BrandingService brandingService;
+    private SettingsBrandingService brandingService;
 
     private TestSettingsBrandingResourceImpl resource;
 
@@ -31,26 +31,26 @@ public class AbstractSettingsBrandingResourceTest {
 
     @Test
     public void testGetColourScheme() {
-        final SettingsBrandingColourSchemeBean bean = SettingsBrandingColourSchemeBean.EXAMPLE_1;
+        final SettingsBrandingColorSchemeBean bean = SettingsBrandingColorSchemeBean.EXAMPLE_1;
 
         doReturn(bean).when(brandingService).getColourScheme();
 
         final Response response = resource.getColourScheme();
         assertEquals(200, response.getStatus());
-        final SettingsBrandingColourSchemeBean colourSchemeBean = (SettingsBrandingColourSchemeBean) response.getEntity();
+        final SettingsBrandingColorSchemeBean colourSchemeBean = (SettingsBrandingColorSchemeBean) response.getEntity();
 
         assertEquals(colourSchemeBean, bean);
     }
 
     @Test
     public void testSetColourScheme() {
-        final SettingsBrandingColourSchemeBean bean = SettingsBrandingColourSchemeBean.EXAMPLE_1;
+        final SettingsBrandingColorSchemeBean bean = SettingsBrandingColorSchemeBean.EXAMPLE_1;
 
         doReturn(bean).when(brandingService).setColourScheme(bean);
 
         final Response response = resource.setColourScheme(bean);
         assertEquals(200, response.getStatus());
-        final SettingsBrandingColourSchemeBean colourSchemeBean = (SettingsBrandingColourSchemeBean) response.getEntity();
+        final SettingsBrandingColorSchemeBean colourSchemeBean = (SettingsBrandingColorSchemeBean) response.getEntity();
 
         assertEquals(colourSchemeBean, bean);
     }

--- a/src/test/java/de/aservo/confapi/commons/rest/TestSettingsBrandingResourceImpl.java
+++ b/src/test/java/de/aservo/confapi/commons/rest/TestSettingsBrandingResourceImpl.java
@@ -1,10 +1,10 @@
 package de.aservo.confapi.commons.rest;
 
-import de.aservo.confapi.commons.service.api.BrandingService;
+import de.aservo.confapi.commons.service.api.SettingsBrandingService;
 
 public class TestSettingsBrandingResourceImpl extends AbstractSettingsBrandingResourceImpl {
 
-    public TestSettingsBrandingResourceImpl(BrandingService brandingService) {
+    public TestSettingsBrandingResourceImpl(SettingsBrandingService brandingService) {
         super(brandingService);
     }
 


### PR DESCRIPTION
this commit fixes class names following the agreed naming convention.
I addition the missing REST pathes were added to SettingsBrandingResource