### PR TITLE
Adjust JUnit testTimeoutHasDefaultValue

### DIFF
--- a/src/test/java/de/aservo/confapi/commons/model/AbstractMailServerProtocolBeanTest.java
+++ b/src/test/java/de/aservo/confapi/commons/model/AbstractMailServerProtocolBeanTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -19,7 +21,7 @@ public class AbstractMailServerProtocolBeanTest {
         assertEquals(timeout, beanWithTimeoutSet.getTimeout().longValue());
 
         final AbstractMailServerProtocolBean beanWithoutTimeoutSet = new AbstractMailServerProtocolBean() {};
-        assertNotNull(beanWithoutTimeoutSet.getTimeout());
+        assertEquals(AbstractMailServerProtocolBean.DEFAULT_TIMEOUT, beanWithoutTimeoutSet.getTimeout());
     }
 
     @Test


### PR DESCRIPTION
Change the assert from 'notNull' to 'Equals' and let the test check if a
new bean will get the default Value.